### PR TITLE
Updating the tooling scripts to automatically launch openocd

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "gdb -q -x openocd.gdb"
+runner = "./runner.sh"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ shared-bus-rtic = "0.1.2"
 
 
 [dependencies.stm32f4xx-hal]
-version = "0.8.3"
+git = "https://github.com/quartiq/stm32f4xx-hal"
 features = ["stm32f407", "rt"]
 
 [dependencies.ad5627]

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -7,8 +7,6 @@ set print asm-demangle on
 set backtrace limit 32
 
 # detect unhandled exceptions, hard faults and panics
-break DefaultHandler
-break HardFault
 break rust_begin_unwind
 # # run the next few lines so the panic message is printed immediately
 # # the number needs to be adjusted for your panic handler
@@ -18,8 +16,6 @@ break rust_begin_unwind
 
 # *try* to stop at the user entry point (it might be gone due to inlining)
 break main
-
-monitor arm semihosting enable
 
 # # send captured ITM to the file itm.fifo
 # # (the microcontroller SWO pin must be connected to the programmer SWO pin)

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash -e
+
+# Start up OpenOCD
+openocd -l openocd.log -f openocd.cfg &
+
+# Start GDB
+gdb-multiarch -q -x openocd.gdb $1
+
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT


### PR DESCRIPTION
This PR updates the tooling scripts in the repository so that you can just call `cargo run` without having to start up openocd. OpenOCD logs are sent to `openocd.log`

This PR also updates the HAL to point to the Quartiq fork. The necessary changes have already landed in the main repository (support for not hanging on NAK for I2C), but there may be further changes necessary