### PR TITLE
Adding fix for AD5627 return voltage calculation

### DIFF
--- a/ad5627/src/lib.rs
+++ b/ad5627/src/lib.rs
@@ -123,7 +123,7 @@ where
         // Write the dac level to the output.
         self.write(Command::WriteInput, dac, code.to_be_bytes())?;
 
-        let programmed_voltage = (code as f32) / (0x1000 as f32) * 2.5;
+        let programmed_voltage = ((code >> 4) as f32) / (0x1000 as f32) * 2.5;
         Ok(programmed_voltage)
     }
 }


### PR DESCRIPTION
This PR adjusts the formula used to return the voltage set by the AD5627. It was not being properly shifted previously.