### PR TITLE
Adding device watchdog support

### DIFF
--- a/src/chassis_fans.rs
+++ b/src/chassis_fans.rs
@@ -139,18 +139,17 @@ impl ChassisFans {
         &mut self,
         delay: &mut impl embedded_hal::blocking::delay::DelayMs<u16>,
     ) -> bool {
-        delay.delay_ms(7000);
-        let dead_rpms = self.read_rpms();
+        self.set_duty_cycles(1.0);
+        delay.delay_ms(5000);
+        let high_rpms = self.read_rpms();
 
         self.set_duty_cycles(0.1);
         delay.delay_ms(7000);
         let low_rpms = self.read_rpms();
 
-        self.set_duty_cycles(1.0);
-        delay.delay_ms(2000);
-        let high_rpms = self.read_rpms();
-
         self.set_duty_cycles(0.0);
+        delay.delay_ms(7000);
+        let dead_rpms = self.read_rpms();
 
         // Check that all dead RPMS are zero.
         let fans_powered_down = dead_rpms.iter().filter(|&rpms| *rpms == 0).count();

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,58 @@
+//! Booster NGFW watchdog manager
+//!
+//! # Copyright
+//! Copyright (C) 2020 QUARTIQ GmbH - All Rights Reserved
+//! Unauthorized usage, editing, or copying is strictly prohibited.
+//! Proprietary and confidential.
+
+use crate::hal;
+use embedded_hal::watchdog::{Watchdog, WatchdogEnable};
+use hal::time::U32Ext;
+
+/// Represents various clients that can check in with the watchdog.
+pub enum WatchdogClient {
+    TelemetryTask = 0,
+    IdleTask = 1,
+    UsbTask = 2,
+    ButtonTask = 3,
+    FanTask = 4,
+    MonitorTask = 5,
+}
+
+/// A manager for the device indepedent watchdog.
+///
+/// The manager waits for a number of clients to check in before feeding the watchdog.
+pub struct WatchdogManager {
+    watchdog: hal::watchdog::IndependentWatchdog,
+    check_ins: [bool; 6],
+}
+
+impl WatchdogManager {
+    /// Construct a new watchdog manager.
+    ///
+    /// # Args
+    /// * `watchdog` - The inedpdent watchdog timer.
+    pub fn new(mut watchdog: hal::watchdog::IndependentWatchdog) -> Self {
+        watchdog.feed();
+        watchdog.start(2_000_u32.ms());
+
+        Self {
+            watchdog,
+            check_ins: [false; 6],
+        }
+    }
+
+    /// Check in with the watchdog.
+    ///
+    /// # Args
+    /// * `client` - The client who is checking in with the watchdog manager.
+    pub fn check_in(&mut self, client: WatchdogClient) {
+        self.check_ins[client as usize] = true;
+
+        // If all clients have checked in, service the watchdog.
+        if self.check_ins.iter().all(|&x| x) {
+            self.watchdog.feed();
+            self.check_ins = [false; 6];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds in watchdog support for the booster. The watchdog is set for a period of 30 seconds during the initialization routines and then configured fro an interval of 2s during normal tasks.

Each task continually checks in to the watchdog. If any of the tasks does not execute within the 2s interval, the watchdog will reset the device.

This PR fixes #12 

**Testing**
The application was run with both the ethernet connected and disconnected. No watchdog timeouts were observed. Then, the code was modified to omit a watchdog service in the USB task. It was observed that the device continually watchdog reset.