### PR TITLE
Fixing panics in release mode

### DIFF
--- a/ads7924/src/lib.rs
+++ b/ads7924/src/lib.rs
@@ -92,7 +92,7 @@ where
         i2c: I2C,
         address: u8,
         avdd: f32,
-        delay: &mut impl DelayUs<u8>,
+        delay: &mut impl DelayUs<u16>,
     ) -> Result<Self, Error> {
         let mut ads7924 = Ads7924 {
             i2c: i2c,
@@ -120,7 +120,7 @@ where
     /// # Args
     /// * `i2c` - The I2C interface to use to communicate with the device.
     /// * `delay` - A means of delaying during initialization.
-    pub fn default(i2c: I2C, delay: &mut impl DelayUs<u8>) -> Result<Self, Error> {
+    pub fn default(i2c: I2C, delay: &mut impl DelayUs<u16>) -> Result<Self, Error> {
         Ads7924::new(i2c, 0x49, 3.434, delay)
     }
 
@@ -145,11 +145,12 @@ where
         Ok(())
     }
 
-    fn reset(&mut self, delay: &mut impl DelayUs<u8>) -> Result<(), Error> {
+    fn reset(&mut self, delay: &mut impl DelayUs<u16>) -> Result<(), Error> {
         self.write(Register::Reset, &[0xAA])?;
-        // The datasheet does not specify any required delay, but experimentally 100uS has been
-        // chosen and observed to behave nominally.
-        delay.delay_us(100u8);
+
+        // Wait a small delay to ensure the device is processing the reset request.
+        delay.delay_us(500_u16);
+
         Ok(())
     }
 

--- a/src/booster_channels.rs
+++ b/src/booster_channels.rs
@@ -100,7 +100,7 @@ impl BoosterChannels {
         adc: hal::adc::Adc<hal::stm32::ADC3>,
         manager: &'static I2cBusManager,
         mut pins: [Option<RfChannelPins>; 8],
-        delay: &mut impl DelayUs<u8>,
+        delay: &mut impl DelayUs<u16>,
     ) -> Self {
         let mut rf_channels: [Option<RfChannel>; 8] =
             [None, None, None, None, None, None, None, None];

--- a/src/rf_channel.rs
+++ b/src/rf_channel.rs
@@ -303,7 +303,7 @@ impl Devices {
     /// # Returns
     /// An option containing the devices if they were discovered on the bus. If any device did not
     /// properly enumerate, the option will be empty.
-    fn new(manager: &'static I2cBusManager, delay: &mut impl DelayUs<u8>) -> Option<Self> {
+    fn new(manager: &'static I2cBusManager, delay: &mut impl DelayUs<u16>) -> Option<Self> {
         // The ADS7924 and DAC7571 are present on the booster mainboard, so instantiation
         // and communication should never fail.
         let mut dac7571 = Dac7571::default(manager.acquire_i2c());
@@ -441,7 +441,7 @@ impl RfChannel {
     pub fn new(
         manager: &'static I2cBusManager,
         control_pins: ChannelPins,
-        delay: &mut impl DelayUs<u8>,
+        delay: &mut impl DelayUs<u16>,
     ) -> Option<Self> {
         // Attempt to instantiate the I2C devices on the channel.
         match Devices::new(manager, delay) {


### PR DESCRIPTION
This PR fixes #67 by increasing the delay after the software reset of the ADS7924 (power monitor external ADC) from 100uS to 500uS. It was found that 100uS was not always sufficient for the reset to occur.

