### PR TITLE
Fixing slope for input/reflected power measurements

### DIFF
--- a/src/rf_channel.rs
+++ b/src/rf_channel.rs
@@ -468,7 +468,10 @@ impl RfChannel {
 
                     // The input power and reflected power detectors are then passed through an
                     // op-amp with gain 1.5x - this modifies the slope from 35mV/dB to 52.5mV/dB
-                    input_power_transform: LinearTransformation::new(1.0 / 1.5 / 0.035, -35.6 + 8.9),
+                    input_power_transform: LinearTransformation::new(
+                        1.0 / 1.5 / 0.035,
+                        -35.6 + 8.9,
+                    ),
                     reflected_power_transform: LinearTransformation::new(
                         1.0 / 1.5 / 0.035,
                         -35.6 + 19.8 + 10.0,


### PR DESCRIPTION
This PR fixes #59 by correcting the slope for input and reflected power calculations.

The 1.5x gain was being multiplied into the slope instead of divided, which was resulting in improper scaling of the voltage into power.