### PR TITLE
Adding CRC32 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "cortex-m-log",
  "cortex-m-rt",
  "cortex-m-rtic",
+ "crc-any",
  "dac7571",
  "debounced-pin",
  "embedded-hal",
@@ -102,7 +103,6 @@ dependencies = [
  "mcp3221",
  "microchip-24aa02e48",
  "minimq",
- "panic-halt",
  "postcard",
  "serde",
  "serde-json-core",
@@ -203,6 +203,12 @@ dependencies = [
  "rtic-syntax",
  "syn",
 ]
+
+[[package]]
+name = "crc-any"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3784befdf9469f4d51c69ef0b774f6a99de6bcc655285f746f16e0dd63d9007"
 
 [[package]]
 name = "dac7571"
@@ -460,12 +466,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "panic-halt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
 
 [[package]]
 name = "postcard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ usbd-serial = "0.1.0"
 shared-bus = { version = "0.2.0-alpha.1", features = ["cortex-m"] }
 usb-device = "0.2.6"
 postcard = "0.5.1"
+crc-any = { version = "2.3.5", default-features = false }
 
 [dependencies.minimq]
 git = "https://github.com/quartiq/minimq"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -9,7 +9,7 @@ use super::hal;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 #[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     // Shutdown all of the RF channels.
     shutdown_channels();
 

--- a/src/settings/sinara.rs
+++ b/src/settings/sinara.rs
@@ -260,8 +260,14 @@ impl SinaraConfiguration {
     }
 
     fn calculate_crc32(&self) -> u32 {
-        // TODO: Calculate using the zlib.crc32 algorithm at
-        // https://github.com/madler/zlib/blob/master/crc32.c#L202-L234
-        0xAAAA_BBBB
+        let mut data = [0u8; 128];
+        self.serialize_into(&mut data);
+
+        // The first 4 bytes of the serialized structure are the CRC itself, so do not include them
+        // in the calculation.
+        let mut crc32 = crc_any::CRC::crc32();
+        crc32.digest(&data[4..]);
+
+        crc32.get_crc() as u32
     }
 }


### PR DESCRIPTION
This PR adds CRC32 support for stored settings using the `crc-any` CRC-32 algorithm.

This fixes #58 