### PR TITLE
Feature/auto release

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,4 +1,4 @@
-name: Tagged Release
+name: tagged-release
 
 on:
     push:
@@ -47,10 +47,10 @@ jobs:
         with:
           command: objcopy --release -- -O binary booster-release.bin
 
-      - uses: marvinpinto/action-automatic-releases@v1.1
+      - uses: marvinpinto/action-automatic-releases@v1.1.0
         with:
           prerelease: false
-          repo_token: '${{ secrets.GITHUB_TOKEN }}'
+          repo_token: '${{ secrets.ACCESS_TOKEN }}'
           files: |
             target/thumbv7em/debug/booster
             target/thumbv7em/release/booster


### PR DESCRIPTION
This PR configures a github action to automatically release when a `v*` tag is pushed to the repository. This allows us to easily generate releases in a consistent manner.

Was tested locally using [`act`](https://github.com/nektos/act).