### PR TITLE
Adding settings version control

### DIFF
--- a/src/settings/channel_settings.rs
+++ b/src/settings/channel_settings.rs
@@ -73,8 +73,8 @@ impl BoosterChannelData {
             return Err(Error::Invalid);
         }
 
-        // Validate the CRC of the settings.
-        if config.version != EXPECTED_VERSION {
+        // Validate the version of the settings.
+        if !EXPECTED_VERSION.is_compatible(&config.version) {
             return Err(Error::Invalid);
         }
 

--- a/src/settings/global_settings.rs
+++ b/src/settings/global_settings.rs
@@ -80,7 +80,8 @@ impl BoosterMainBoardData {
     pub fn deserialize(data: &[u8; 64]) -> Result<Self, Error> {
         let config: BoosterMainBoardData = postcard::from_bytes(data).unwrap();
 
-        if config.version != EXPECTED_VERSION {
+        // Validate the version of the settings.
+        if !EXPECTED_VERSION.is_compatible(&config.version) {
             return Err(Error::Invalid);
         }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -21,3 +21,10 @@ pub struct SemVersion {
     minor: u8,
     patch: u8,
 }
+
+impl SemVersion {
+    /// Determine if this version is compatible with `rhs`.
+    pub fn is_compatible(&self, rhs: &SemVersion) -> bool {
+        (self.major == rhs.major) && (self.minor <= rhs.minor)
+    }
+}


### PR DESCRIPTION
This PR fixes #120 by adding a semver to the channel and global settings on booster, which can be used to automatically detect settings version mismatches.

@hartytp Would you mind giving this branch a try to see if it resolves your reset issue in #119?