### PR TITLE
Adding blocked reason to state reporting

### DIFF
--- a/src/rf_channel.rs
+++ b/src/rf_channel.rs
@@ -54,7 +54,7 @@ pub struct SupplyMeasurements {
 pub enum ChannelFault {
     OverTemperature,
     UnderTemperature,
-    Alert,
+    SupplyAlert,
 }
 
 /// Represents the three power interlocks present on the device.
@@ -97,8 +97,8 @@ pub enum ChannelState {
 impl serde::Serialize for ChannelState {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match *self {
-            ChannelState::Blocked(ChannelFault::Alert) => {
-                serializer.serialize_unit_variant("ChannelState", 0, "Blocked(Alert)")
+            ChannelState::Blocked(ChannelFault::SupplyAlert) => {
+                serializer.serialize_unit_variant("ChannelState", 0, "Blocked(SupplyAlert)")
             }
             ChannelState::Blocked(ChannelFault::UnderTemperature) => {
                 serializer.serialize_unit_variant("ChannelState", 0, "Blocked(UnderTempeterature)")
@@ -585,7 +585,7 @@ impl RfChannel {
         } else if temperature < 5.0 {
             Some(ChannelFault::UnderTemperature)
         } else if self.pins.alert.is_low().unwrap() {
-            Some(ChannelFault::Alert)
+            Some(ChannelFault::SupplyAlert)
         } else {
             None
         }


### PR DESCRIPTION
This PR aids in the determination of the root cause of #130 by reporting the ChannelFault that caused the `Blocked` channel state. This can then be read over MQTT to determine the cause of the channel fault.

It also renames the `OverCurrent` fault to `Alert` to properly reflect what is being reported. The ALERT signal is no longer monitoring current thresholds.