### PR TITLE
Reducing channel_monitor service rate from 50Hz -> 10Hz

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,9 +549,9 @@ const APP: () = {
         c.resources.leds.update();
 
         // TODO: Replace hard-coded CPU cycles here.
-        // Schedule to run this task periodically at 50Hz.
+        // Schedule to run this task periodically at 10Hz.
         c.schedule
-            .channel_monitor(c.scheduled + Duration::from_cycles(168_000_000 / 50))
+            .channel_monitor(c.scheduled + Duration::from_cycles(168_000_000 / 10))
             .unwrap();
     }
 


### PR DESCRIPTION
This PR reduces the service rate of the channel monitor from 50Hz to 10Hz.

Initial measurements and tracing are showing that the `channel_monitor` task takes approximately 8ms with 8 channels installed. With a 50Hz duty cycle, this corresponds with the `channel_monitor` task taking up 40% of the CPU processing cycle.

When coupled with the 1.8s delay of the idle task, it was observed that the idle task periodically still wasn't checking in with the watchdog in time. By reducing the overall channel monitor service rate, we reduce the pre-emption overhead (added execution duration) of all other (long) tasks from 40% to approximately 8%, which means that the longer executing tasks should have significantly shorter execution times.