### PR TITLE
Adding handling for W5500 socket disconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/minimq#4a2b850b647b575d832122eeb2ffdeaa3677835a"
+source = "git+https://github.com/quartiq/minimq#83e946544cebd09c9dd07ff1271be639138ec1ce"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/src/mqtt_control.rs
+++ b/src/mqtt_control.rs
@@ -310,6 +310,12 @@ impl ControlState {
                 // to re-establish them once we reconnect.
                 Err(minimq::Error::Disconnected) => self.subscribed = false,
 
+                // Note: There's a race condition where the W5500 may disconnect the socket
+                // immediately before Minimq tries to use it. In these cases, a NotReady error is
+                // returned to indicate the socket is no longer connected. On the next processing
+                // cycle of Minimq, the device should detect and handle the broker disconnection.
+                Err(minimq::Error::Network(w5500::Error::NotReady)) => {}
+
                 Err(e) => error!("Unexpected error: {:?}", e),
             }
         });


### PR DESCRIPTION
This PR fixes #146 by updating Booster to handle and ignore `NotReady` indications, which are provided by the W5500 NAL whenever `send()` or `recv()` is called on a socket that is no longer connected. This rectifies a race condition in Minimq. Additionally, Minimq was updated to a version that does not contain the mentioned unwrap.

**Testing**
I cycled the broker on and off repeatedly over ~10 times and did not observe booster reset.