### PR TITLE
Removing error on I2C bus fault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +467,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2178127478ae4ee9be7180bc9c3bffb6354dd7238400db567102f98c413a9f35"
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +566,15 @@ name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
+name = "rtcc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1048f7217bcd4bd977c01288e4973a69cf9195681f8b0b3a45d92ea21148f4a8"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "rtic-core"
@@ -640,7 +678,7 @@ dependencies = [
 [[package]]
 name = "stm32f4xx-hal"
 version = "0.8.3"
-source = "git+https://github.com/stm32-rs/stm32f4xx-hal#1dabe771eb141139ff1a2ead4f97a9036b4e9521"
+source = "git+https://github.com/stm32-rs/stm32f4xx-hal#c8b11b200ac3c5f9be802f8f9e39755b1cb5933a"
 dependencies = [
  "bare-metal",
  "cast",
@@ -650,6 +688,7 @@ dependencies = [
  "embedded-hal",
  "nb 0.1.3",
  "rand_core",
+ "rtcc",
  "stm32f4",
  "synopsys-usb-otg",
  "void",
@@ -758,8 +797,3 @@ dependencies = [
  "no-std-net",
  "num_enum",
 ]
-
-[[patch.unused]]
-name = "stm32f4xx-hal"
-version = "0.8.3"
-source = "git+https://github.com/quartiq/stm32f4xx-hal?branch=rs/issue-274/i2c-bus-errors#47ba4649ba8c8dafce8c9613ee821ea140d59223"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,6 @@ git = "https://github.com/quartiq/minimq"
 git = "https://github.com/stm32-rs/stm32f4xx-hal"
 features = ["stm32f407", "rt", "usb_fs"]
 
-[patch.crates-io.stm32f4xx-hal]
-git = "https://github.com/quartiq/stm32f4xx-hal"
-branch = "rs/issue-274/i2c-bus-errors"
-
 [dependencies.w5500]
 git = "https://github.com/quartiq/w5500"
 branch = "feature/tcp-nal"


### PR DESCRIPTION
This PR updates the HAL to utilize a new version that properly ignores the I2C BERR bit.

This fixes #128 