### PR TITLE
Fixing USB enumeration on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,9 +1069,8 @@ dependencies = [
 
 [[package]]
 name = "usb-device"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849eed9b4dc61a1f17ba1d7a5078ceb095b9410caa38a506eb281ed5eff12fbd"
+version = "0.2.8"
+source = "git+https://github.com/ryan-summers/usb-device?rev=abdf004#abdf0045e374535cf73db57bc85749470604f6c7"
 
 [[package]]
 name = "usbd-serial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ logos = { version = "0.11.4", default-features = false, features = ["export_deri
 bbqueue = "0.4.10"
 usbd-serial = "0.1.0"
 shared-bus = { version = "0.2.0-alpha.1", features = ["cortex-m"] }
-usb-device = "0.2.6"
+usb-device = "0.2.8"
 postcard = "0.5.1"
 crc-any = { version = "2.3.5", default-features = false }
 panic-persist = { git = "https://github.com/jamesmunns/panic-persist", branch = "master", features = ["custom-panic-handler"] }
@@ -52,6 +52,10 @@ git = "https://git.m-labs.hk/M-Labs/ENC424J600.git"
 rev = "fbcc3778d27cfbeec7a1395c9b13a00c8a26af9a"
 features = [ "smoltcp-phy", "cortex-m-cpu" ]
 optional = true
+
+[patch.crates-io.usb-device]
+git = "https://github.com/ryan-summers/usb-device"
+rev = "abdf004"
 
 [dependencies.ad5627]
 path = "ad5627"


### PR DESCRIPTION
This PR fixes #165 by using a patch of `usb-device` to properly handle partial descriptor reads during SETUP.

Ubuntu did a bus reset after the partial read, which reconfigured the device state and reset the error, but on Windows, no reset is present and the next "Set Address" stage fails.