### PR TITLE
Updating dependencies to use const-generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +54,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+dependencies = [
+ "critical-section",
+ "riscv-target",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,13 +79,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bbqueue"
-version = "0.4.10"
+name = "bare-metal"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6ffd9a6d04298eb55d5ac6d0fde48c2f991468b5ba8aa263fe2d1ea7288c0a"
-dependencies = [
- "generic-array 0.13.3",
-]
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
+name = "bbqueue"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3baa8859d1a4c7411039a75c0599a4640ef1c9a8fc811e4325b00e6cfe0a55"
 
 [[package]]
 name = "beef"
@@ -101,7 +123,7 @@ dependencies = [
  "bbqueue",
  "bit_field",
  "built",
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
  "cortex-m-log",
  "cortex-m-rt",
  "cortex-m-rtic",
@@ -112,7 +134,7 @@ dependencies = [
  "embedded-time",
  "enc424j600",
  "enum-iterator",
- "heapless 0.5.6",
+ "heapless 0.7.9",
  "log",
  "logos",
  "max6639",
@@ -187,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,20 +234,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59971a5cf4dacacaf738dd9d8660875118fce790f800f661893eb20894c1d622"
 dependencies = [
  "aligned 0.2.0",
- "bare-metal",
- "cortex-m 0.6.3",
+ "bare-metal 0.2.5",
+ "cortex-m 0.6.7",
  "volatile-register",
 ]
 
 [[package]]
 name = "cortex-m"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be99930c99669a74d986f7fd2162085498b322e6daae8ef63a97cc9ac1dc73c"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
 dependencies = [
  "aligned 0.3.4",
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
+ "cortex-m 0.7.4",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
+dependencies = [
+ "bare-metal 0.2.5",
+ "bitfield",
+ "embedded-hal",
  "volatile-register",
 ]
 
@@ -229,7 +270,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d63959cb1e003dd97233fee6762351540253237eadf06fcdcb98cbfa3f9be4a"
 dependencies = [
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
  "log",
 ]
 
@@ -260,7 +301,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b30efcb6b7920d9016182c485687f0012487032a14c415d2fce6e9862ef8260e"
 dependencies = [
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
  "cortex-m-rt",
  "cortex-m-rtic-macros",
  "heapless 0.5.6",
@@ -285,6 +326,18 @@ name = "crc-any"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3784befdf9469f4d51c69ef0b774f6a99de6bcc655285f746f16e0dd63d9007"
+
+[[package]]
+name = "critical-section"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if 1.0.0",
+ "cortex-m 0.7.4",
+ "riscv",
+]
 
 [[package]]
 name = "dac7571"
@@ -451,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +526,7 @@ checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
 dependencies = [
  "as-slice",
  "generic-array 0.13.3",
- "hash32",
+ "hash32 0.1.1",
  "serde",
  "stable_deref_trait",
 ]
@@ -477,7 +539,20 @@ checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
 dependencies = [
  "as-slice",
  "generic-array 0.14.4",
- "hash32",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "serde",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -512,6 +587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +623,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -608,6 +698,12 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "microchip-24aa02e48"
@@ -734,11 +830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "panic-persist"
 version = "0.2.1"
 source = "git+https://github.com/jamesmunns/panic-persist?branch=master#3f892297e97adc6a415145193000e3749b1959df"
 dependencies = [
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
 ]
 
 [[package]]
@@ -801,10 +903,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
+name = "regex"
+version = "1.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "rtcc"
@@ -842,6 +977,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,11 +1023,12 @@ dependencies = [
 
 [[package]]
 name = "serde-json-core"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fd6016a00149b485f66da701f76d909210d319040c97b6eff300f6e2ba2153"
+checksum = "8014aeea272bca0f0779778d43253f2f3375b414185b30e6ecc4d3e4a9994781"
 dependencies = [
- "heapless 0.5.6",
+ "heapless 0.7.9",
+ "ryu",
  "serde",
 ]
 
@@ -901,7 +1049,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f42e140835229dea9c0b2498d2c88afe52ed2bd42a7cc6068c95adb5134b541"
 dependencies = [
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
  "embedded-hal",
 ]
 
@@ -928,6 +1076,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,8 +1096,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11460b4de3a84f072e2cf6e76306c64d27f405a0e83bace0a726f555ddf4bf33"
 dependencies = [
- "bare-metal",
- "cortex-m 0.6.3",
+ "bare-metal 0.2.5",
+ "cortex-m 0.6.7",
  "cortex-m-rt",
  "vcell",
 ]
@@ -950,9 +1107,9 @@ name = "stm32f4xx-hal"
 version = "0.8.3"
 source = "git+https://github.com/stm32-rs/stm32f4xx-hal#c8b11b200ac3c5f9be802f8f9e39755b1cb5933a"
 dependencies = [
- "bare-metal",
+ "bare-metal 0.2.5",
  "cast",
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
  "cortex-m-rt",
  "embedded-dma",
  "embedded-hal",
@@ -981,7 +1138,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "461676dcf123675b3d3b02e2390e6a690cd186aacf2f439af7673c79e2561d53"
 dependencies = [
- "cortex-m 0.6.3",
+ "cortex-m 0.6.7",
  "usb-device",
  "vcell",
 ]
@@ -991,6 +1148,15 @@ name = "tca9548"
 version = "0.1.0"
 dependencies = [
  "embedded-hal",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ embedded-hal = "0.2.4"
 enum-iterator = "0.6.0"
 cortex-m-log = { version = "0.6.1", features = ["log-integration"] }
 log = "0.4.8"
-heapless = { version = "0.5.5", features = ["serde"] }
+heapless = { version = "0.7", features = ["serde"] }
 bit_field = "0.10.0"
 debounced-pin = "0.3.0"
 serde = {version = "1.0", features = ["derive"], default-features = false }
-serde-json-core = "0.2"
+serde-json-core = "0.4"
 logos = { version = "0.11.4", default-features = false, features = ["export_derive"] }
-bbqueue = "0.4.10"
+bbqueue = "0.5"
 usbd-serial = "0.1.0"
 shared-bus = { version = "0.2.0-alpha.1", features = ["cortex-m"] }
 usb-device = "0.2.6"

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -405,8 +405,7 @@ pub fn setup(
         let usb_bus =
             cortex_m::singleton!(: Option<usb_device::bus::UsbBusAllocator<UsbBus>> = None)
                 .unwrap();
-        let serial_number =
-            cortex_m::singleton!(: Option<String<heapless::consts::U64>> = None).unwrap();
+        let serial_number = cortex_m::singleton!(: Option<String<64>> = None).unwrap();
 
         let usb = hal::otg_fs::USB {
             usb_global: device.OTG_FS_GLOBAL,
@@ -423,7 +422,7 @@ pub fn setup(
 
         // Generate a device serial number from the MAC address.
         {
-            let mut serial_string: String<heapless::consts::U64> = String::new();
+            let mut serial_string: String<64> = String::new();
 
             #[cfg(feature = "phy_w5500")]
             let octets = settings.mac().octets;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -4,7 +4,7 @@
 //! Copyright (C) 2020 QUARTIQ GmbH - All Rights Reserved
 //! Unauthorized usage, editing, or copying is strictly prohibited.
 //! Proprietary and confidential.
-use heapless::{consts, String};
+use heapless::String;
 
 use super::SerialTerminal;
 use core::fmt::Write;
@@ -16,7 +16,7 @@ use core::fmt::Write;
 /// intended to be consumed asynchronously. In the case of booster, this log data is consumed in the
 /// USB task.
 pub struct BufferedLog {
-    logs: heapless::mpmc::Q16<heapless::String<consts::U128>>,
+    logs: heapless::mpmc::Q16<heapless::String<128>>,
 }
 
 impl BufferedLog {
@@ -48,7 +48,7 @@ impl log::Log for BufferedLog {
         let source_line = record.line().unwrap_or(u32::MAX);
 
         // Print the record into the buffer.
-        let mut string: String<consts::U128> = String::new();
+        let mut string: String<128> = String::new();
         match write!(
             &mut string,
             "[{}] {}:{} - {}\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ const APP: () = {
         usb_terminal: SerialTerminal,
         eth_mgr: EthernetManager,
         watchdog: WatchdogManager,
-        identifier: String<heapless::consts::U32>,
+        identifier: String<32>,
         delay: AsmDelay,
     }
 
@@ -87,7 +87,7 @@ const APP: () = {
 
         let watchdog_manager = WatchdogManager::new(booster.watchdog);
 
-        let identifier: String<heapless::consts::U32> = String::from(booster.settings.id());
+        let identifier: String<32> = String::from(booster.settings.id());
 
         // Kick-start the periodic software tasks.
         c.schedule.channel_monitor(c.start).unwrap();
@@ -227,11 +227,10 @@ const APP: () = {
 
             if let Ok(measurements) = measurements {
                 // Broadcast the measured data over the telemetry interface.
-                let mut topic: String<heapless::consts::U32> = String::new();
+                let mut topic: String<32> = String::new();
                 write!(&mut topic, "{}/ch{}", id, channel as u8).unwrap();
 
-                let message: String<heapless::consts::U1024> =
-                    serde_json_core::to_string(&measurements).unwrap();
+                let message: String<1024> = serde_json_core::to_string(&measurements).unwrap();
 
                 match c.resources.eth_mgr.mqtt_client.publish(
                     topic.as_str(),

--- a/src/settings/global_settings.rs
+++ b/src/settings/global_settings.rs
@@ -5,7 +5,7 @@
 //! Unauthorized usage, editing, or copying is strictly prohibited.
 //! Proprietary and confidential.
 use crate::{hardware::Eeprom, Error};
-use heapless::{consts, String};
+use heapless::String;
 use minimq::embedded_nal::Ipv4Addr;
 use serde::{Deserialize, Serialize};
 
@@ -53,7 +53,7 @@ impl BoosterMainBoardData {
     /// # Args
     /// * `eui48` - The EUI48 identifier of the booster mainboard.
     pub fn default(eui48: &[u8; 6]) -> Self {
-        let mut name: String<consts::U23> = String::new();
+        let mut name: String<23> = String::new();
         write!(
             &mut name,
             "booster{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",


### PR DESCRIPTION
This PR updates various dependencies to use the latest and greatest const-generics support. This is a step towards adding miniconf support as documented in #160 