### PR TITLE
Simplifying boot to DFU support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,28 +103,3 @@ jobs:
           path: |
             target/*/release/booster
             booster-release.bin
-
-  compile-unstable:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [phy_w5500, phy_enc424j600]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust Nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: thumbv7em-none-eabihf
-          override: true
-      - name: cargo build+unstable
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features --features "unstable ${{ matrix.variant }}"
-      - name: cargo build+release+unstable
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --no-default-features --features "unstable ${{ matrix.variant }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ path = "microchip-24aa02e48"
 path = "tca9548"
 
 [features]
-unstable = []
 phy_enc424j600 = [ "enc424j600", "smoltcp-nal", "embedded-time" ]
 phy_w5500 = [ "w5500" ]
 default = [ "phy_w5500" ]

--- a/src/hardware/platform.rs
+++ b/src/hardware/platform.rs
@@ -105,7 +105,6 @@ pub fn clear_reset_flags() {
     rcc.csr.modify(|_, w| w.rmvf().set_bit());
 }
 
-#[cfg(feature = "unstable")]
 /// Reset the device to the internal DFU bootloader.
 pub fn reset_to_dfu_bootloader() {
     // Disable the SysTick peripheral.
@@ -154,13 +153,8 @@ pub fn reset_to_dfu_bootloader() {
     // address from system memory and begin execution. The datasheet indicates that
     // the initial stack pointer is stored at an offset of 0x0000 and the first
     // instruction begins at an offset of 0x0004.
-    let system_memory_address: u32 = 0x1FFF_0000;
     unsafe {
-        core::arch::asm!(
-            "LDR sp, [r3, #0]\n
-             LDR r3, [r3, #4]\n
-             BX r3\n",
-             in("r3") system_memory_address,
-        );
+        let system_memory_address: *const u32 = 0x1FFF_0000 as *const u32;
+        cortex_m::asm::bootload(system_memory_address);
     }
 }

--- a/src/serial_terminal.rs
+++ b/src/serial_terminal.rs
@@ -143,7 +143,6 @@ impl SerialTerminal {
                     cortex_m::peripheral::SCB::sys_reset();
                 }
 
-                #[cfg(feature = "unstable")]
                 Request::ResetBootloader => {
                     cortex_m::interrupt::disable();
 
@@ -151,13 +150,6 @@ impl SerialTerminal {
                     platform::shutdown_channels();
 
                     platform::reset_to_dfu_bootloader();
-                }
-
-                #[cfg(not(feature = "unstable"))]
-                Request::ResetBootloader => {
-                    self.write(
-                        "Reset to DFU bootloader not supported with stable toolchain".as_bytes(),
-                    );
                 }
 
                 Request::ServiceInfo => {


### PR DESCRIPTION
This PR fixes #179 by using `cortex_m::asm::bootload()` to reset into the DFU using the stable toolchain.

Manual bench testing indicates the DFU command is successful and the device begins enumerating as an STM32 DFU device in device manager.