### PR TITLE
Fixing bias tuning script

### DIFF
--- a/booster.py
+++ b/booster.py
@@ -157,8 +157,7 @@ class BoosterApi:
             the measured RF amplifier drain current.
         """
         # Power up the channel. Wait for the channel to fully power-up before continuing.
-        await self.settings_interface.command(f'channel/{channel}/rf_disable', True, retain=False)
-        await self.settings_interface.command(f'channel/{channel}/enabled', True, retain=False)
+        await self.settings_interface.command(f'channel/{channel}/state', "Powered", retain=False)
         await asyncio.sleep(0.4)
 
         async def set_bias(voltage):


### PR DESCRIPTION
This PR fixes an invalid settings path that wasn't updated when the power state was refactored.