### PR TITLE
Correcting tagged-release workflow

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -3,8 +3,8 @@ name: tagged-release
 on:
   workflow_dispatch:
   push:
-    #    tags:
-    #      - "v*"
+    tags:
+      - "v*"
 
 jobs:
   tagged-release:
@@ -45,4 +45,4 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VERSION_TAG: ${GITHUB_REF##*/}
         run: |
-          hub release create --draft -a "target/thumbv7em-none-eabihf/release/booster#booster-release" -a "booster-release.bin" -m "Release ${{env.VERSION_TAG}}" ${{env.VERSION_TAG}}
+          hub release create -a "target/thumbv7em-none-eabihf/release/booster#booster-release" -a "booster-release.bin" -m "Release ${{env.VERSION_TAG}}" ${{env.VERSION_TAG}}


### PR DESCRIPTION
* Allowing manual execution of the tagged-release workflow
* Fixing bash string substitution
* Removing `debug` builds

Tested successfully creating a release in 5af71f9214fec48750b6d3be6bb8e46056668f9b, although I have since deleted the draft release.