### PR TITLE
Updating booster to ignore republish data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.3.0"
-source = "git+https://github.com/quartiq/miniconf?rev=94825b6#94825b62c75b59713ec7f512bdf58b1cb539793c"
+source = "git+https://github.com/quartiq/miniconf?rev=140b6f3#140b6f339fb1fdaab6547a960441898c6ac66e0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.3.0"
-source = "git+https://github.com/quartiq/miniconf?rev=94825b6#94825b62c75b59713ec7f512bdf58b1cb539793c"
+source = "git+https://github.com/quartiq/miniconf?rev=140b6f3#140b6f339fb1fdaab6547a960441898c6ac66e0e"
 dependencies = [
  "derive_miniconf",
  "heapless 0.7.9",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "minimq"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf42a70baa4f1f568529bd8b9ae388cac43cd31a506197e6c26e9cf647aa9014"
+checksum = "4c8e06869d0d2be282e85fdbabdd6f8103155f583f2169206cf6cfc75f3f6474"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ panic-persist = { version = "0.3", features = ["custom-panic-handler"] }
 smoltcp-nal = { version = "0.2.0", optional = true }
 embedded-time = { version = "0.12.0", optional = true }
 miniconf = { version = "0.3", features = ["mqtt-client"]}
-minimq = "0.5"
+minimq = "0.5.3"
 w5500 = { version = "0.4", optional = true }
 smlang= "0.5"
 
@@ -50,7 +50,7 @@ optional = true
 
 [patch.crates-io.miniconf]
 git = "https://github.com/quartiq/miniconf"
-rev = "94825b6"
+rev = "140b6f3"
 
 [patch.crates-io.usb-device]
 git = "https://github.com/ryan-summers/usb-device"


### PR DESCRIPTION
This PR fixes #206 by bumping the Miniconf revision to include https://github.com/quartiq/miniconf/pull/82, which updated Miniconf to ignore inbound messages that are related to republishing.

On my local setup:
* Verified that short disconnection, such that MQTT client does not drop, results in no republished settings
* Verified that disconnecting ethernet for > 2 minutes, validating that the broker registers the connections as lost, and then reconnecting the ethernet does result in a republish, but does not result in a STANDBY channel being improperly enabled.