### PR TITLE
Updating usb-device dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Settings are backwards compatible with previous Booster releases.
 * Fan speed is now stored in EEPROM and configurable via the serial interface.
 
+### Fixed
+* A few dependencies were deprecated because changes landed upstream. These dependencies were
+  corrected to point upstream.
+
 ## [0.3.0]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "usb-device"
 version = "0.2.8"
-source = "git+https://github.com/ryan-summers/usb-device?rev=abdf004#abdf0045e374535cf73db57bc85749470604f6c7"
+source = "git+https://github.com/rust-embedded-community/usb-device#413b77cd38d200c3b0e777dd3055cb7ef82c46a0"
 
 [[package]]
 name = "usbd-serial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,7 @@ git = "https://github.com/quartiq/miniconf"
 rev = "140b6f3"
 
 [patch.crates-io.usb-device]
-git = "https://github.com/ryan-summers/usb-device"
-rev = "abdf004"
+git = "https://github.com/rust-embedded-community/usb-device"
 
 [dependencies.ad5627]
 path = "ad5627"


### PR DESCRIPTION
This PR fixes #224 by updating the usb-device dependency.

- [x] The Basic HITL test script was executed against this change to verify the device behaves normally.
- [x] I also connected USB to verify everything worked as expected.