### PR TITLE
Correcting CHANGELOG for 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* The W5500 now operates as an external MAC, and smoltcp is used as the network stack.
-* DHCP support has been added, `netmask`, `ip-address`, and `gateway` settings have been removed.
-  Settings are backwards compatible with previous Booster releases.
-* Fan speed is now stored in EEPROM and configurable via the serial interface.
 * Support for different ethernet daughterboards using the ENC424J00 has been added.
 
 ### Changed
@@ -19,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * A few dependencies were deprecated because changes landed upstream. These dependencies were
   corrected to point upstream.
+
+## [0.4.0]
+
+### Added
+* The W5500 now operates as an external MAC, and smoltcp is used as the network stack.
+* DHCP support has been added, `netmask`, `ip-address`, and `gateway` settings have been removed.
+  Settings are backwards compatible with previous Booster releases.
+* Fan speed is now stored in EEPROM and configurable via the serial interface.
 
 ## [0.3.0]
 
@@ -44,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Output interlock threshold is now limited to a maximum of 47 dBm
 
-[Unreleased]: https://github.com/quartiq/booster/compare/v0.3.0...HEAD
-[v0.3.0]: https://github.com/quartiq/booster/compare/v0.2.0...v0.3.0
-[v0.2.0]: https://github.com/quartiq/booster/compare/v0.1.0...v0.2.0
-[v0.1.0]: https://github.com/quartiq/booster/compare/v0.0.1...v0.1.0
+[Unreleased]: https://github.com/quartiq/booster/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/quartiq/booster/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/quartiq/booster/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/quartiq/booster/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/quartiq/booster/compare/v0.0.1...v0.1.0


### PR DESCRIPTION
This PR fixes #232 by adding an entry for the 0.4.0 firmware release