### PR TITLE
Updating fans to remain on whenever channels are powered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Removed custom `mutex` implementation in favor of leveraging `shared-bus`
+* Fans will now remain on whenever a channel is powered as opposed to actively outputting RF. This
+  addresses heating issues observed with some Booster configurations resulting in channel wedging.
 
 ### Fixed
 * A few dependencies were deprecated because changes landed upstream. These dependencies were

--- a/src/hardware/rf_channel.rs
+++ b/src/hardware/rf_channel.rs
@@ -333,6 +333,11 @@ impl RfChannel {
         self.pins.signal_on.is_high().unwrap()
     }
 
+    /// Check if the channel is powered.
+    pub fn is_powered(&self) -> bool {
+        self.pins.enable_power.is_high().unwrap()
+    }
+
     /// Set the interlock thresholds for the channel.
     ///
     /// # Args

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ mod app {
                     .channels
                     .channel_mut(idx)
                     .map(|(channel, _)| {
-                        if channel.context().is_enabled() {
+                        if channel.context().is_powered() {
                             fans_enabled = true;
                         }
 


### PR DESCRIPTION
This PR addresses #245 by updating Booster to keep fans on whenever a channel is powered vs. when one is enabled.

Tested by placing one booster channel into the "Powered" state and observing the fan spin-up. Confirmed that pressing the "Standby" button properly then disabled fans, and "Interlock reset" resulted in the channel being repowered and fans re-spinning.