### PR TITLE
Removing release generation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,3 @@ Booster is an 8 channel RF power amplifier in the Sinara open hardware ecosystem
 The open hardware designs and hardware discussions are located at
 https://github.com/sinara-hw/Booster/wiki.
 The hardware is available from Creotech, QUARTIQ, Technosyste, and M-Labs.
-
-# Generating Releases
-
-When a release is ready, `develop` must be merged into `master`.
-
-The corresponding merge commit is then tagged with the version in the form of `vX.Y.Z`, where X, Y,
-and Z are the semantic version major, minor, and patch versions. The tag must be pushed using `git
-push origin vX.Y.Z`. This will automatically trigger CI to generate the release.
-
-After the tag is generated, `master` must be merged back into `develop`.


### PR DESCRIPTION
This PR removes release generation docs in preparation for migrating everything to the `master` branch