### PR TITLE
Replacing postcard with encdec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Serial port now supports TeraTerm + Putty
 * Serial port now supports backspacing
 * Support for static IP + netmask and gateway configuration
+    * NOTE: Boosters that used firmware from before 0.4.0 will return to old network configurations.
+    To re-enable DHCP, reconfigure the IP address to 0.0.0.0/0
 
 ### Changed
 * Removed custom `mutex` implementation in favor of leveraging `shared-bus`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,12 +55,11 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.5"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
  "critical-section",
- "riscv-target",
 ]
 
 [[package]]
@@ -75,7 +74,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -131,8 +130,9 @@ dependencies = [
  "dac7571",
  "debounced-pin",
  "enc424j600",
- "enum-iterator",
- "heapless 0.7.9",
+ "encdec",
+ "enum-iterator 1.2.0",
+ "heapless",
  "log",
  "logos",
  "max6639",
@@ -144,7 +144,6 @@ dependencies = [
  "minireq",
  "mono-clock",
  "panic-persist",
- "postcard",
  "rtt-logger",
  "rtt-target",
  "serde",
@@ -172,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-lock"
@@ -194,7 +193,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -305,7 +304,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m 0.7.4",
  "cortex-m-rtic-macros",
- "heapless 0.7.9",
+ "heapless",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -332,9 +331,9 @@ checksum = "c3784befdf9469f4d51c69ef0b774f6a99de6bcc655285f746f16e0dd63d9007"
 
 [[package]]
 name = "critical-section"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
+checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if 1.0.0",
@@ -347,6 +346,41 @@ name = "dac7571"
 version = "0.1.0"
 dependencies = [
  "embedded-hal",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -404,7 +438,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9efecb57ab54fa918730f2874d7d37647169c50fa1357fecb81abee840b113"
 dependencies = [
- "heapless 0.7.9",
+ "heapless",
  "nb 1.0.0",
  "no-std-net",
 ]
@@ -430,12 +464,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "encdec"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda2e74abc9ec9cdf26491d775b6aead82f4b815771f3783a9c49917ad109981"
+dependencies = [
+ "encdec-base",
+ "encdec-macros",
+]
+
+[[package]]
+name = "encdec-base"
+version = "0.8.1"
+source = "git+https://github.com/quartiq/rust-encdec?branch=feature/float-support#8209c0d07a107eb74367fb5f49ba98bc526132d7"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "encdec-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c898bd5ea39ac4cd7f5b2ba72d8bc66d92833c586158e76d6c5f06aa1aaeff06"
+dependencies = [
+ "darling",
+ "encdec-base",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enum-iterator"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
 dependencies = [
- "enum-iterator-derive",
+ "enum-iterator-derive 0.6.0",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+dependencies = [
+ "enum-iterator-derive 1.1.0",
 ]
 
 [[package]]
@@ -443,6 +518,17 @@ name = "enum-iterator-derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -526,15 +612,6 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
@@ -550,29 +627,23 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heapless"
-version = "0.5.6"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
-dependencies = [
- "as-slice",
- "generic-array 0.13.3",
- "hash32 0.1.1",
- "serde",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32 0.2.1",
+ "hash32",
+ "rustc_version 0.4.0",
  "serde",
  "spin",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -736,7 +807,7 @@ version = "0.3.0"
 source = "git+https://github.com/quartiq/miniconf?rev=140b6f3#140b6f339fb1fdaab6547a960441898c6ac66e0e"
 dependencies = [
  "derive_miniconf",
- "heapless 0.7.9",
+ "heapless",
  "log",
  "minimq",
  "serde",
@@ -753,8 +824,8 @@ dependencies = [
  "bit_field",
  "embedded-nal",
  "embedded-time",
- "enum-iterator",
- "heapless 0.7.9",
+ "enum-iterator 0.6.0",
+ "heapless",
  "smlang 0.4.2",
 ]
 
@@ -763,7 +834,7 @@ name = "minireq"
 version = "0.1.0"
 source = "git+https://github.com/quartiq/minireq?rev=786bc8845819a26a3669d6e0c81d64b71f510573#786bc8845819a26a3669d6e0c81d64b71f510573"
 dependencies = [
- "heapless 0.7.9",
+ "heapless",
  "log",
  "minimq",
  "serde",
@@ -863,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -904,23 +975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "postcard"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3f5c2e9a91383c6594ec68aa2dfdfe19a3c86f34b088ba7203f2483d2682f"
-dependencies = [
- "heapless 0.5.6",
- "postcard-cobs",
- "serde",
-]
-
-[[package]]
-name = "postcard-cobs"
-version = "0.1.5-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,18 +1000,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1076,6 +1130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,7 +1189,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8014aeea272bca0f0779778d43253f2f3375b414185b30e6ecc4d3e4a9994781"
 dependencies = [
- "heapless 0.7.9",
+ "heapless",
  "ryu",
  "serde",
 ]
@@ -1211,7 +1274,7 @@ checksum = "c7b22fc1e9b13e435081ae7f593ab1e5385a3884c2134c753c7fb5729d675373"
 dependencies = [
  "embedded-nal",
  "embedded-time",
- "heapless 0.7.9",
+ "heapless",
  "nanorand",
  "smoltcp",
 ]
@@ -1263,14 +1326,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.94"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1354,6 +1423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,12 +1436,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ exclude = [
 cortex-m = "0.7.4"
 cortex-m-rt = "0.6.10"
 cortex-m-rtic = "1.0"
-enum-iterator = "0.6.0"
 mono-clock = "0.1"
 systick-monotonic = "1.0.0"
 cortex-m-log = { version = "0.7.0", features = ["log-integration"] }
@@ -44,7 +43,7 @@ bbqueue = "0.5"
 usbd-serial = "0.1.0"
 shared-bus = { version = "0.2", features = ["cortex-m"] }
 usb-device = "0.2.8"
-postcard = "0.5.1"
+encdec = { version = "0.8", default-features = false }
 crc-any = { version = "2.3.5", default-features = false }
 panic-persist = { version = "0.3", features = ["custom-panic-handler", "utf8"] }
 smoltcp-nal = { version = "0.2" }
@@ -54,6 +53,7 @@ w5500 = { version = "0.4", optional = true }
 smlang= "0.5"
 minireq = "0.1"
 rtt-target = {version = "0.3", features=["cortex-m"]}
+enum-iterator = { version = "1.2", default-features = false }
 
 [build-dependencies]
 built = { version = "0.5", features = ["git2"], default-features = false }
@@ -84,6 +84,10 @@ rev = "140b6f3"
 
 [patch.crates-io.usb-device]
 git = "https://github.com/rust-embedded-community/usb-device"
+
+[patch.crates-io.encdec-base]
+git = "https://github.com/quartiq/rust-encdec"
+branch = "feature/float-support"
 
 [dependencies.ad5627]
 path = "ad5627"

--- a/src/hardware/booster_channels.rs
+++ b/src/hardware/booster_channels.rs
@@ -1,6 +1,5 @@
 //! Booster NGFW channel management control interface definitions.
 
-use enum_iterator::IntoEnumIterator;
 use stm32f4xx_hal as hal;
 use tca9548::{self, Tca9548};
 
@@ -56,7 +55,7 @@ impl BoosterChannels {
         let mut channels: [Option<RfChannelMachine>; 8] =
             [None, None, None, None, None, None, None, None];
 
-        for (idx, pins) in Channel::into_enum_iter().zip(pins) {
+        for (idx, pins) in enum_iterator::all::<Channel>().zip(pins) {
             // Selecting an I2C bus should never fail.
             mux.select_bus(Some(idx.into()))
                 .expect("Failed to select channel");

--- a/src/hardware/chassis_fans.rs
+++ b/src/hardware/chassis_fans.rs
@@ -1,8 +1,8 @@
 //! Booster NGFW Application
 
 use super::{I2cError, I2cProxy, MainboardLeds};
-use stm32f4xx_hal::hal::digital::v2::OutputPin;
 use max6639::Max6639;
+use stm32f4xx_hal::hal::digital::v2::OutputPin;
 
 /// The default fan speed on power-up.
 pub const DEFAULT_FAN_SPEED: f32 = 0.2;

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -1,7 +1,7 @@
 //! Booster module-level hardware definitions
 
 use core::fmt::Write;
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use serde::{Deserialize, Serialize};
 use stm32f4xx_hal as hal;
 
@@ -74,7 +74,7 @@ pub type UsbBus = hal::otg_fs::UsbBus<hal::otg_fs::USB>;
 pub type Eeprom = microchip_24aa02e48::Microchip24AA02E48<I2C2>;
 
 /// Indicates a booster RF channel.
-#[derive(IntoEnumIterator, Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Sequence, Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum Channel {
     Zero = 0,
     One = 1,

--- a/src/hardware/rf_channel.rs
+++ b/src/hardware/rf_channel.rs
@@ -16,10 +16,10 @@ use crate::{
     Error,
 };
 use stm32f4xx_hal::{
-    hal::blocking::delay::DelayUs,
     self as hal,
     adc::config::SampleTime,
     gpio::{Analog, Floating, Input, Output, PullDown, PushPull},
+    hal::blocking::delay::DelayUs,
     prelude::*,
 };
 

--- a/src/hardware/user_interface.rs
+++ b/src/hardware/user_interface.rs
@@ -2,11 +2,11 @@
 
 use super::Channel;
 use bit_field::BitField;
-use stm32f4xx_hal as hal;
 use hal::hal::{
     blocking::spi::Write,
     digital::v2::{InputPin, OutputPin},
 };
+use stm32f4xx_hal as hal;
 
 use debounced_pin::{Debounce, DebounceState, DebouncedInputPin};
 

--- a/src/linear_transformation.rs
+++ b/src/linear_transformation.rs
@@ -1,9 +1,12 @@
 //! Booster NGFW linear-transformation routines
 
+use encdec::{Decode, Encode};
 use miniconf::Miniconf;
 
 /// A structure for mapping values between two different domains.
-#[derive(Miniconf, serde::Serialize, serde::Deserialize, Copy, Clone, PartialEq)]
+#[derive(
+    Miniconf, serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, Encode, Decode,
+)]
 pub struct LinearTransformation {
     slope: f32,
     offset: f32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ compile_error!(
 #[cfg(all(feature = "phy_enc424j600", feature = "phy_w5500"))]
 compile_error!("Cannot enable multiple ethernet PHY devices.");
 
-use enum_iterator::IntoEnumIterator;
 use stm32f4xx_hal as hal;
 
 #[macro_use]
@@ -85,7 +84,7 @@ mod app {
         // Load the default fan speed
         settings.fan_speed = booster.settings.fan_speed();
 
-        for idx in Channel::into_enum_iter() {
+        for idx in enum_iterator::all::<Channel>() {
             settings.channel[idx as usize] = booster
                 .main_bus
                 .channels
@@ -139,7 +138,7 @@ mod app {
         let mut fans_enabled = false;
 
         let leds = c.local.leds;
-        for idx in Channel::into_enum_iter() {
+        for idx in enum_iterator::all::<Channel>() {
             let status = c.shared.main_bus.lock(|main_bus| {
                 main_bus
                     .channels
@@ -179,7 +178,7 @@ mod app {
     fn telemetry(mut c: telemetry::Context) {
         // Gather telemetry for all of the channels.
         // And broadcast the measured data over the telemetry interface.
-        for idx in Channel::into_enum_iter() {
+        for idx in enum_iterator::all::<Channel>() {
             (&mut c.shared.main_bus, &mut c.shared.net_devices).lock(|main_bus, net_devices| {
                 main_bus.channels.channel_mut(idx).map(|(ch, adc)| {
                     net_devices
@@ -205,7 +204,7 @@ mod app {
             .lock(|watchdog| watchdog.check_in(WatchdogClient::Button));
 
         if let Some(event) = c.local.buttons.update() {
-            for idx in Channel::into_enum_iter() {
+            for idx in enum_iterator::all::<Channel>() {
                 c.shared.main_bus.lock(|main_bus| {
                     main_bus
                         .channels
@@ -234,7 +233,7 @@ mod app {
             .net_devices
             .lock(|net_devices| net_devices.settings.settings().clone());
 
-        for idx in Channel::into_enum_iter() {
+        for idx in enum_iterator::all::<Channel>() {
             c.shared.main_bus.lock(|main_bus| {
                 main_bus
                     .channels

--- a/src/settings/channel_settings.rs
+++ b/src/settings/channel_settings.rs
@@ -2,6 +2,8 @@
 
 use super::{SemVersion, SinaraBoardId, SinaraConfiguration};
 use crate::{hardware::I2cProxy, linear_transformation::LinearTransformation, Error};
+use encdec::{Decode, DecodeOwned, Encode};
+use enum_iterator::Sequence;
 use microchip_24aa02e48::Microchip24AA02E48;
 use miniconf::Miniconf;
 
@@ -14,7 +16,10 @@ const EXPECTED_VERSION: SemVersion = SemVersion {
 };
 
 /// Indicates the desired state of a channel.
-#[derive(serde::Serialize, serde::Deserialize, Miniconf, Copy, Clone, PartialEq)]
+#[derive(
+    serde::Serialize, serde::Deserialize, Miniconf, Debug, Copy, Clone, PartialEq, Sequence,
+)]
+#[repr(u8)]
 pub enum ChannelState {
     /// The channel should be turned off and power should be disconnected.
     Off = 0,
@@ -27,8 +32,46 @@ pub enum ChannelState {
     Powered = 2,
 }
 
+impl Encode for ChannelState {
+    type Error = encdec::Error;
+
+    fn encode_len(&self) -> Result<usize, Self::Error> {
+        Ok(1)
+    }
+
+    fn encode(&self, buff: &mut [u8]) -> Result<usize, Self::Error> {
+        if buff.len() < 1 {
+            return Err(encdec::Error::Length);
+        }
+
+        buff[0] = *self as u8;
+
+        Ok(1)
+    }
+}
+
+impl DecodeOwned for ChannelState {
+    type Output = ChannelState;
+
+    type Error = encdec::Error;
+
+    fn decode_owned(buff: &[u8]) -> Result<(Self::Output, usize), Self::Error> {
+        if buff.len() < 1 {
+            return Err(encdec::Error::Length);
+        }
+
+        for state in enum_iterator::all::<ChannelState>() {
+            if state as u8 == buff[0] {
+                return Ok((state, 1));
+            }
+        }
+
+        Err(encdec::Error::Utf8)
+    }
+}
+
 /// Represents booster channel-specific configuration values.
-#[derive(Miniconf, serde::Serialize, serde::Deserialize, Copy, Clone, PartialEq)]
+#[derive(Miniconf, Encode, DecodeOwned, Debug, Copy, Clone, PartialEq)]
 pub struct ChannelSettings {
     pub output_interlock_threshold: f32,
     pub bias_voltage: f32,
@@ -67,7 +110,7 @@ impl Default for ChannelSettings {
 }
 
 /// Represents versioned channel-specific configuration values.
-#[derive(serde::Serialize, serde::Deserialize, Copy, Clone)]
+#[derive(Encode, DecodeOwned, Debug, Copy, Clone)]
 struct VersionedChannelData {
     version: SemVersion,
     settings: ChannelSettings,
@@ -92,7 +135,7 @@ impl VersionedChannelData {
     /// # Returns
     /// The configuration if deserialization was successful. Otherwise, returns an error.
     pub fn deserialize(data: &[u8; 64]) -> Result<Self, Error> {
-        let data: VersionedChannelData = postcard::from_bytes(data).or(Err(Error::Invalid))?;
+        let (data, _) = VersionedChannelData::decode_owned(data).or(Err(Error::Invalid))?;
 
         // Validate configuration parameters.
         if data.settings.bias_voltage < -3.3 || data.settings.bias_voltage > 0.0 {
@@ -120,8 +163,8 @@ impl VersionedChannelData {
         }
 
         let mut buffer: [u8; 64] = [0; 64];
-        let serialized = postcard::to_slice(&versioned_copy, &mut buffer).unwrap();
-        config.board_data[..serialized.len()].copy_from_slice(serialized);
+        let len = versioned_copy.encode(&mut buffer).unwrap();
+        config.board_data[..len].copy_from_slice(&buffer[..len]);
     }
 }
 

--- a/src/settings/global_settings.rs
+++ b/src/settings/global_settings.rs
@@ -187,7 +187,7 @@ impl BoosterSettings {
         // Save the updated configuration to EEPROM.
         let mut serialized = [0u8; 128];
         config.serialize_into(&mut serialized);
-        //self.eeprom.write(0, &serialized).unwrap();
+        self.eeprom.write(0, &serialized).unwrap();
     }
 
     /// Get the Booster unique identifier.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -4,6 +4,8 @@ pub mod channel_settings;
 pub mod global_settings;
 pub mod runtime_settings;
 mod sinara;
+use encdec::{Decode, DecodeOwned, Encode};
+use serde::{Deserialize, Serialize};
 
 use sinara::{BoardId as SinaraBoardId, SinaraConfiguration};
 
@@ -11,7 +13,7 @@ pub use channel_settings::BoosterChannelSettings;
 pub use global_settings::BoosterSettings;
 
 /// A semantic version control for recording software versions.
-#[derive(serde::Serialize, serde::Deserialize, PartialEq, Copy, Clone)]
+#[derive(Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 pub struct SemVersion {
     major: u8,
     minor: u8,

--- a/src/settings/runtime_settings.rs
+++ b/src/settings/runtime_settings.rs
@@ -5,7 +5,6 @@ use crate::{
     hardware::{self, platform, Channel},
     net,
 };
-use enum_iterator::IntoEnumIterator;
 use miniconf::Miniconf;
 
 #[derive(Clone, Miniconf)]
@@ -36,7 +35,7 @@ impl RuntimeSettings {
         settings: &mut Self,
         new_settings: &Self,
     ) -> Result<(), &'static str> {
-        for idx in Channel::into_enum_iter() {
+        for idx in enum_iterator::all::<Channel>() {
             if let Some(ref settings) = new_settings.channel[idx as usize] {
                 // Check that the interlock thresholds are sensible.
                 if settings.output_interlock_threshold > platform::MAX_OUTPUT_POWER_DBM {


### PR DESCRIPTION
This PR replaces `postcard` with `encdec`. `encdec` is more suitable for our precise storage requirements.

I tested this with my current Booster and confirmed that my settings were retained. I also updated parameters and verified that they stuck