### PR TITLE
Removing usb-device patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,8 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "usb-device"
-version = "0.2.8"
-source = "git+https://github.com/rust-embedded-community/usb-device#413b77cd38d200c3b0e777dd3055cb7ef82c46a0"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
 name = "usbd-serial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rtt-logger = "0.2"
 bbqueue = "0.5"
 usbd-serial = "0.1.0"
 shared-bus = { version = "0.2", features = ["cortex-m"] }
-usb-device = "0.2.8"
+usb-device = "0.2.9"
 encdec = { version = "0.8", default-features = false }
 crc-any = { version = "2.4.3", default-features = false }
 panic-persist = { version = "0.3", features = ["custom-panic-handler", "utf8"] }
@@ -71,9 +71,6 @@ git = "https://git.m-labs.hk/M-Labs/ENC424J600.git"
 rev = "fbcc3778d27cfbeec7a1395c9b13a00c8a26af9a"
 features = [ "cortex-m-cpu" ]
 optional = true
-
-[patch.crates-io.usb-device]
-git = "https://github.com/rust-embedded-community/usb-device"
 
 [dependencies.ad5627]
 path = "ad5627"


### PR DESCRIPTION
This PR removes the patch for `usb-device` now that 0.2.9 is released and addresses our fixes for Windows enumeration.