### PR TITLE
Updating booster docs location

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -38,6 +38,7 @@ jobs:
 
       - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: book/booster-manual/html
           enable_jekyll: true
           publish_branch: pages

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   release-docs:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -38,7 +38,6 @@ jobs:
 
       - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
-          deploy_key: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: book/booster-manual/html
           enable_jekyll: true
           publish_branch: pages

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -38,9 +38,8 @@ jobs:
 
       - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
-          deploy_key: ${{ secrets.PAGES_DEPLOY }}
+          deploy_key: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: book/booster-manual/html
           enable_jekyll: true
           publish_branch: pages
           force_orphan: true
-          external_repository: quartiq/booster-doc

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ in the original firmware, and to enable continued maintenance and improvements.
 
 # Documentation
 
-Please see the [Online Documentation](https://quartiq.de/booster-doc) for usage information.
+Please see the [Online Documentation](https://quartiq.de/booster) for usage information.
 
 # License
 


### PR DESCRIPTION
This PR fixes #255 by adding the docs to be published under this repo now that the firmware is open-sourced