### PR TITLE
Updating hitl trigger to mirror HITL result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,12 @@ jobs:
             {"github": ${{ toJson(github) }}, "check_id": ${{steps.hitl-check.outputs.check_id}}}
 
       - uses: fountainhead/action-wait-for-check@v1.0.0
+        id: status
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: HITL Run Status
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: "Check HITL Status"
+        if: steps.status.outputs.conclusion != 'success'
+        run: exit -1


### PR DESCRIPTION
Fixes #315 by updating the `hitl-trigger` status check to only indicate success if the HITL was actually successful