### PR TITLE
Feature/mqtt updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - '1.65.0'
+          - '1.72.0'
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "minireq"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/minireq#d2b1d69f6318b30b4483d6e8dcf4f4c3d86310e5"
+source = "git+https://github.com/quartiq/minireq?branch=feature/republish-state-fix#98c22c909253ae47934695fb4bb00a6f941bdc31"
 dependencies = [
  "embedded-io",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "rtt-logger",
  "rtt-target",
  "serde",
+ "serde-json-core",
  "shared-bus 0.3.0",
  "smlang",
  "smoltcp-nal",
@@ -433,6 +434,12 @@ dependencies = [
  "embedded-hal 1.0.0-alpha.11",
  "nb 1.1.0",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bbadc628dc286b9ae02f0cb0f5411c056eb7487b72f0083203f115de94060"
 
 [[package]]
 name = "embedded-nal"
@@ -849,8 +856,7 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e34fb3249ad071debda2ceb8d29e271d0fd283039f7bf04d9d7921dec4e6b4e"
+source = "git+https://github.com/quartiq/miniconf#61946c1a739abb79870fedcb096c5cd697eee361"
 dependencies = [
  "heapless",
  "itoa",
@@ -865,8 +871,7 @@ dependencies = [
 [[package]]
 name = "miniconf_derive"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2327f540b14c86184b066abe25daca988c15c60f0d9a215d2a37f3032805d47"
+source = "git+https://github.com/quartiq/miniconf#61946c1a739abb79870fedcb096c5cd697eee361"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -876,8 +881,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0106439fe4eb2e88c5b6b8fcb505b2f679bd8e105c947aa1f1a77f6b57a38653"
+source = "git+https://github.com/quartiq/minimq#cec9ce70a9091b4e20d3b09c0efe8341dc762f41"
 dependencies = [
  "bit_field",
  "embedded-nal 0.7.0",
@@ -892,14 +896,13 @@ dependencies = [
 [[package]]
 name = "minireq"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85d60240fb77183cd698380356928ed5314cf574d69252aef36024156bcb423"
+source = "git+https://github.com/quartiq/minireq#d2b1d69f6318b30b4483d6e8dcf4f4c3d86310e5"
 dependencies = [
+ "embedded-io",
  "heapless",
  "log",
  "minimq",
  "serde",
- "serde-json-core",
  "smlang",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "minireq"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/minireq?branch=feature/republish-state-fix#98c22c909253ae47934695fb4bb00a6f941bdc31"
+source = "git+https://github.com/quartiq/minireq#b7a4c90714e1695c953b355b26e05e967aea782e"
 dependencies = [
  "embedded-io",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ miniconf = { git = "https://github.com/quartiq/miniconf", features = ["mqtt-clie
 minimq = { git = "https://github.com/quartiq/minimq" }
 w5500 = "0.4.1"
 smlang= "0.6"
-minireq = { git = "https://github.com/quartiq/minireq", branch = "feature/republish-state-fix" }
+minireq = { git = "https://github.com/quartiq/minireq" }
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "1.4", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 documentation = "https://quartiq.de/booster-doc/"
 edition = "2018"
 # keep MSRV in sync in ci.yaml, Cargo.toml
-rust-version = "1.65"
+rust-version = "1.72"
 build = "build.rs"
 exclude = [
 	".gitignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 ]
 
 [dependencies]
+serde-json-core = "0.5"
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.1"
@@ -46,11 +47,11 @@ usb-device = "0.2.9"
 encdec = { version = "0.9", default-features = false }
 crc-any = { version = "2.4.3", default-features = false }
 panic-persist = { version = "0.3", features = ["custom-panic-handler", "utf8"] }
-miniconf = { version = "0.8", features = ["mqtt-client"]}
-minimq = "0.7"
+miniconf = { git = "https://github.com/quartiq/miniconf", features = ["mqtt-client"]}
+minimq = { git = "https://github.com/quartiq/minimq" }
 w5500 = "0.4.1"
 smlang= "0.6"
-minireq = "0.2"
+minireq = { git = "https://github.com/quartiq/minireq" }
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "1.4", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ miniconf = { git = "https://github.com/quartiq/miniconf", features = ["mqtt-clie
 minimq = { git = "https://github.com/quartiq/minimq" }
 w5500 = "0.4.1"
 smlang= "0.6"
-minireq = { git = "https://github.com/quartiq/minireq" }
+minireq = { git = "https://github.com/quartiq/minireq", branch = "feature/republish-state-fix" }
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "1.4", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ encdec = { version = "0.9", default-features = false }
 crc-any = { version = "2.4.3", default-features = false }
 panic-persist = { version = "0.3", features = ["custom-panic-handler", "utf8"] }
 miniconf = { git = "https://github.com/quartiq/miniconf", features = ["mqtt-client"]}
+# Note: Keep `py/pyproject.toml` version in sync with the Minimq version used in FW.
 minimq = { git = "https://github.com/quartiq/minimq" }
 w5500 = "0.4.1"
 smlang= "0.6"

--- a/hitl/basic.py
+++ b/hitl/basic.py
@@ -39,12 +39,11 @@ async def channel_on(booster, channel, initial_state='Enabled'):
     """
     try:
         print(f'Commanding channel {channel} into {initial_state}')
-        await booster.settings_interface.command(f'channel/{channel}/state', initial_state,
-                                                 retain=False)
+        await booster.settings_interface.set(f'/channel/{channel}/state', initial_state)
         yield
     finally:
         print(f'Commanding channel {channel} off')
-        await booster.settings_interface.command(f'channel/{channel}/state', 'Off', retain=False)
+        await booster.settings_interface.set(f'/channel/{channel}/state', 'Off')
 
 
 async def test_channel(booster, channel, prefix, broker):
@@ -67,7 +66,7 @@ async def test_channel(booster, channel, prefix, broker):
         print(f'Channel {channel} bias tuning: Vgs = {vgs}, Ids = {ids}')
 
     # Disable the channel.
-    await booster.settings_interface.command(f'channel/{channel}/state', 'Off', retain=False)
+    await booster.settings_interface.set(f'/channel/{channel}/state', 'Off')
 
     # Check that telemetry indicates channel is powered off.
     async def is_off() -> bool:
@@ -78,8 +77,7 @@ async def test_channel(booster, channel, prefix, broker):
 
     # Set the interlock threshold so that it won't trip.
     print('Setting output interlock threshold to 30 dB')
-    await booster.settings_interface.command(f'channel/{channel}/output_interlock_threshold', 30,
-                                             retain=False)
+    await booster.settings_interface.set(f'/channel/{channel}/output_interlock_threshold', 30)
 
     # Enable the channel, verify telemetry indicates it is now enabled.
     async with channel_on(booster, channel):
@@ -91,8 +89,7 @@ async def test_channel(booster, channel, prefix, broker):
 
         # Lower the interlock threshold so it trips.
         print('Setting output interlock threshold to -5 dB, verifying interlock trips')
-        await booster.settings_interface.command(f'channel/{channel}/output_interlock_threshold',
-                                                 -5.7, retain=False)
+        await booster.settings_interface.set(f'/channel/{channel}/output_interlock_threshold', -5.7)
 
         async def is_tripped() -> bool:
             _, tlm = await telemetry.get_next_telemetry()
@@ -121,7 +118,7 @@ def main():
         booster = await BoosterApi.create(args.prefix, args.broker)
 
         # Disable configure the telemetry rate.
-        await booster.settings_interface.command('telemetry_period', 1, retain=False)
+        await booster.settings_interface.set('/telemetry_period', 1, retain=False)
 
         # Test operation of an RF channel
         for channel in args.channels:

--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -41,7 +41,7 @@ sleep 30
 ping -c 5 -w 20 booster-hitl
 
 # Test the MQTT interface.
-python3 -m miniconf --discover $PREFIX telemetry_period=5
+python3 -m miniconf --discover $PREFIX /telemetry_period=5
 
 # Test basic operation
 python3 hitl/basic.py

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -14,5 +14,6 @@ authors = [
     { name = "Robert Jördens", email = "rj@quartiq.de" },
 ]
 dependencies = [
-    "miniconf-mqtt@git+https://github.com/quartiq/miniconf@v0.8.0#subdirectory=py/miniconf-mqtt",
+    # Note: keep this in sync with Cargo.toml
+    "miniconf-mqtt@git+https://github.com/quartiq/miniconf@main#subdirectory=py/miniconf-mqtt",
 ]

--- a/src/linear_transformation.rs
+++ b/src/linear_transformation.rs
@@ -1,12 +1,9 @@
 //! Booster NGFW linear-transformation routines
 
 use encdec::{Decode, Encode};
-use miniconf::Miniconf;
 
 /// A structure for mapping values between two different domains.
-#[derive(
-    Miniconf, serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, Encode, Decode,
-)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, Encode, Decode)]
 pub struct LinearTransformation {
     slope: f32,
     offset: f32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,8 @@ mod app {
             SharedResources {
                 main_bus: booster.main_bus,
                 net_devices: net::NetworkDevices::new(
-                    // TODO: Replace with settings.
-                    //minimq::embedded_nal::IpAddr::V4(booster.settings.broker()),
-                    "mqtt",
+                    // TODO: Replace with hostname-based broker.
+                    minimq::embedded_nal::IpAddr::V4(booster.settings.broker()),
                     booster.network_stack,
                     booster.settings.id(),
                     settings,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,9 @@ mod app {
             SharedResources {
                 main_bus: booster.main_bus,
                 net_devices: net::NetworkDevices::new(
-                    minimq::embedded_nal::IpAddr::V4(booster.settings.broker()),
+                    // TODO: Replace with settings.
+                    //minimq::embedded_nal::IpAddr::V4(booster.settings.broker()),
+                    "mqtt",
                     booster.network_stack,
                     booster.settings.id(),
                     settings,
@@ -307,11 +309,10 @@ mod app {
             c.shared
                 .net_devices
                 .lock(|net| {
-                    match net
-                        .control
-                        .poll(|handler, topic, data| main_bus.lock(|bus| handler(bus, topic, data)))
-                    {
-                        Err(minireq::Error::Mqtt(minimq::Error::Network(
+                    match net.control.poll(|handler, topic, data, output| {
+                        main_bus.lock(|bus| handler(bus, topic, data, output))
+                    }) {
+                        Err(minireq::Error::Mqtt(minireq::minimq::Error::Network(
                             smoltcp_nal::NetworkError::TcpConnectionFailure(
                                 smoltcp_nal::smoltcp::socket::tcp::ConnectError::Unaddressable,
                             ),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -39,7 +39,7 @@ pub struct NetworkDevices {
         crate::RuntimeSettings,
         NetworkStackProxy,
         SystemTimer,
-        miniconf::minimq::broker::NamedBroker<NetworkStackProxy>,
+        minireq::minimq::broker::IpBroker,
         4,
     >,
     pub control: minireq::Minireq<
@@ -47,7 +47,7 @@ pub struct NetworkDevices {
         MainBus,
         NetworkStackProxy,
         SystemTimer,
-        minireq::minimq::broker::NamedBroker<NetworkStackProxy>,
+        minireq::minimq::broker::IpBroker,
         mqtt_control::Error,
     >,
     stack: NetworkStackProxy,
@@ -61,7 +61,7 @@ impl NetworkDevices {
     /// * `stack` - The network stack to use for communications.
     /// * `identifier` - The unique identifier of this device.
     pub fn new(
-        broker: &str,
+        broker: minimq::embedded_nal::IpAddr,
         stack: NetworkStack,
         identifier: &str,
         settings: crate::RuntimeSettings,
@@ -81,8 +81,7 @@ impl NetworkDevices {
             let mut client_id: String<128> = String::new();
             write!(&mut client_id, "booster-{}-req", identifier).unwrap();
 
-            let broker =
-                minireq::minimq::broker::NamedBroker::new(broker, shared.acquire_stack()).unwrap();
+            let broker = minireq::minimq::broker::IpBroker::new(broker);
             let config = minireq::minimq::ConfigBuilder::new(broker, &mut store.settings)
                 .client_id(&client_id)
                 .unwrap();
@@ -105,8 +104,7 @@ impl NetworkDevices {
             let mut client_id: String<64> = String::new();
             write!(&mut client_id, "booster-{}-tlm", identifier).unwrap();
 
-            let broker =
-                miniconf::minimq::broker::NamedBroker::new(broker, shared.acquire_stack()).unwrap();
+            let broker = minireq::minimq::broker::IpBroker::new(broker);
             let config = miniconf::minimq::ConfigBuilder::new(broker, &mut store.telemetry)
                 .client_id(&client_id)
                 .unwrap();
@@ -121,8 +119,7 @@ impl NetworkDevices {
             let mut client_id: String<128> = String::new();
             write!(&mut client_id, "booster-{}-settings", identifier).unwrap();
 
-            let broker =
-                miniconf::minimq::broker::NamedBroker::new(broker, shared.acquire_stack()).unwrap();
+            let broker = minireq::minimq::broker::IpBroker::new(broker);
             let config = miniconf::minimq::ConfigBuilder::new(broker, &mut store.control)
                 .client_id(&client_id)
                 .unwrap();

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -106,6 +106,9 @@ impl NetworkDevices {
 
             let broker = minireq::minimq::broker::IpBroker::new(broker);
             let config = miniconf::minimq::ConfigBuilder::new(broker, &mut store.telemetry)
+                // The telemetry client doesn't do much in terms of receiving data, so reserve the
+                // buffer for transmission.
+                .rx_buffer(miniconf::minimq::config::BufferConfig::Maximum(100))
                 .client_id(&client_id)
                 .unwrap();
             mqtt_control::TelemetryClient::new(

--- a/src/settings/channel_settings.rs
+++ b/src/settings/channel_settings.rs
@@ -5,7 +5,7 @@ use crate::{hardware::I2cProxy, linear_transformation::LinearTransformation, Err
 use encdec::{Decode, DecodeOwned, Encode};
 use enum_iterator::Sequence;
 use microchip_24aa02e48::Microchip24AA02E48;
-use miniconf::Miniconf;
+use miniconf::Tree;
 use serde::{Deserialize, Serialize};
 
 /// The expected semver of the BoosterChannelSettings. This version must be updated whenever the
@@ -70,7 +70,7 @@ impl DecodeOwned for ChannelState {
 }
 
 /// Represents booster channel-specific configuration values.
-#[derive(Miniconf, Encode, DecodeOwned, Debug, Copy, Clone, PartialEq)]
+#[derive(Tree, Encode, DecodeOwned, Debug, Copy, Clone, PartialEq)]
 pub struct ChannelSettings {
     pub output_interlock_threshold: f32,
     pub bias_voltage: f32,

--- a/src/settings/runtime_settings.rs
+++ b/src/settings/runtime_settings.rs
@@ -5,11 +5,11 @@ use crate::{
     hardware::{self, platform, Channel},
     net,
 };
-use miniconf::Miniconf;
+use miniconf::Tree;
 
-#[derive(Clone, Miniconf)]
+#[derive(Clone, Tree)]
 pub struct RuntimeSettings {
-    #[miniconf(defer(3))]
+    #[tree(depth(3))]
     pub channel: [Option<ChannelSettings>; 8],
 
     /// The normalized fan speed. 1.0 corresponds to 100% on and 0.0 corresponds to completely


### PR DESCRIPTION
Updates the miniconf client and traits, updates the minireq client, and updates the minimq telemetry client.

The refactor should lessen the stack usage of the application, as we serialize the MQTT traffic into preallocated, static buffers now.

This also enables us to quickly switch over to using a DNS-based broker scheme, but I want to hold off on that for another PR. The Booster main board settings structure is running quite low on space (it only has 64 bytes), and I want to discuss where the broker hostname should be stored first.