### PR TITLE
Replacing serial terminal with menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Network stack is randomly seeded on startup so that random ports are used.
+* Serial terminal replaced with `menu` for simplicity
 
 ## [0.5.0] - 03-07-2023
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,12 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3baa8859d1a4c7411039a75c0599a4640ef1c9a8fc811e4325b00e6cfe0a55"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,10 +143,10 @@ dependencies = [
  "enum-iterator",
  "heapless",
  "log",
- "logos",
  "max6639",
  "max6642",
  "mcp3221",
+ "menu",
  "microchip-24aa02e48",
  "miniconf",
  "minimq",
@@ -783,29 +777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "logos"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
-dependencies = [
- "beef",
- "fnv",
- "proc-macro2",
- "quote",
- "regex-syntax",
- "syn 1.0.105",
-]
-
-[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +816,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "menu"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03d7f798bfe97329ad6df937951142eec93886b37d87010502dd25e8cc75fd5"
 
 [[package]]
 name = "microchip-24aa02e48"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "rtt-target",
  "serde",
  "serde-json-core",
+ "serde_with",
  "shared-bus 0.3.0",
  "smlang",
  "smoltcp-nal",
@@ -345,8 +346,18 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -364,14 +375,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.2",
  "quote",
  "syn 1.0.105",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -520,7 +556,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15497932aae6b53bf8548cc63c65929b4fab6be54e28709c80fc72f5707eeed"
 dependencies = [
- "darling",
+ "darling 0.14.2",
  "encdec-base 0.8.2",
  "proc-macro2",
  "quote",
@@ -1265,6 +1301,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ heapless = { version = "0.7", features = ["serde"] }
 bit_field = "0.10.2"
 debounced-pin = "0.3.0"
 serde = {version = "1.0", features = ["derive"], default-features = false }
-logos = { version = "0.12.1", default-features = false, features = ["export_derive"] }
+menu = "0.3"
 rtt-logger = "0.2"
 bbqueue = "0.5"
 usbd-serial = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 ]
 
 [dependencies]
+serde_with = { version = "3.3", default-features = false, features = ["macros"] }
 serde-json-core = "0.5"
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7"

--- a/src/hardware/net_interface.rs
+++ b/src/hardware/net_interface.rs
@@ -64,10 +64,10 @@ pub fn setup(
 ) {
     let net_store = cortex_m::singleton!(: NetStorage = NetStorage::new()).unwrap();
 
-    let ip_address = settings.ip_address();
+    let ip_address = settings.properties.ip_cidr();
 
     let mut config =
-        smoltcp::iface::Config::new(smoltcp::wire::HardwareAddress::Ethernet(settings.mac()));
+        smoltcp::iface::Config::new(smoltcp::wire::HardwareAddress::Ethernet(settings.mac));
     config.random_seed = random_seed;
 
     let mut interface =
@@ -75,7 +75,7 @@ pub fn setup(
 
     interface
         .routes_mut()
-        .add_default_ipv4_route(settings.gateway())
+        .add_default_ipv4_route(settings.properties.gateway.0)
         .unwrap();
 
     let mut sockets = smoltcp::iface::SocketSet::new(&mut net_store.sockets[..]);

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -342,7 +342,7 @@ pub fn setup(
 
             let w5500 = w5500::UninitializedDevice::new(w5500::bus::FourWire::new(spi, cs))
                 .initialize_macraw(w5500::MacAddress {
-                    octets: settings.mac().0,
+                    octets: settings.mac.0,
                 })
                 .unwrap();
 
@@ -350,7 +350,7 @@ pub fn setup(
         } else {
             let mut mac = enc424j600::Enc424j600::new(spi, cs).cpu_freq_mhz(CPU_FREQ / 1_000_000);
             mac.init(&mut delay).expect("PHY initialization failed");
-            mac.write_mac_addr(settings.mac().as_bytes()).unwrap();
+            mac.write_mac_addr(settings.mac.as_bytes()).unwrap();
 
             Mac::Enc424j600(mac)
         }
@@ -409,7 +409,11 @@ pub fn setup(
             max6639::Max6639::new(i2c_bus_manager.acquire_i2c(), max6639::AddressPin::Pullup)
                 .unwrap();
 
-        ChassisFans::new([fan1, fan2, fan3], main_board_leds, settings.fan_speed())
+        ChassisFans::new(
+            [fan1, fan2, fan3],
+            main_board_leds,
+            settings.properties.fan_speed,
+        )
     };
 
     assert!(fans.self_test(&mut delay));
@@ -442,7 +446,7 @@ pub fn setup(
         {
             let mut serial_string: String<64> = String::new();
 
-            let octets = settings.mac().0;
+            let octets = settings.mac.0;
 
             write!(
                 &mut serial_string,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ mod app {
         let mut settings = RuntimeSettings::default();
 
         // Load the default fan speed
-        settings.fan_speed = booster.settings.fan_speed();
+        settings.fan_speed = booster.settings.properties.fan_speed;
 
         for idx in enum_iterator::all::<Channel>() {
             settings.channel[idx as usize] = booster
@@ -97,9 +97,9 @@ mod app {
                 main_bus: booster.main_bus,
                 net_devices: net::NetworkDevices::new(
                     // TODO: Replace with hostname-based broker.
-                    minimq::embedded_nal::IpAddr::V4(booster.settings.broker()),
+                    booster.settings.properties.broker(),
                     booster.network_stack,
-                    booster.settings.id(),
+                    &booster.settings.properties.id,
                     settings,
                     clock,
                     booster.metadata,

--- a/src/serial_terminal.rs
+++ b/src/serial_terminal.rs
@@ -258,7 +258,7 @@ fn handle_property_read(
         match context.settings.properties.get_json(&path, &mut buf) {
             Ok(len) => {
                 let str_prop = core::str::from_utf8(&buf[..len]).unwrap();
-                writeln!(context, "{prop}: {str_prop}").unwrap();
+                writeln!(context, "{prop:<20}: {str_prop}").unwrap();
             }
             Err(e) => writeln!(context, "Failed to retrieve setting: {e:?}").unwrap(),
         }
@@ -278,7 +278,12 @@ fn handle_property_read(
         }
 
         // Print out MAC address
-        writeln!(context.output_buffer, "mac: {}", context.settings.mac).unwrap();
+        writeln!(
+            context.output_buffer,
+            "{:<20}: {}",
+            "mac", context.settings.mac
+        )
+        .unwrap();
     }
 }
 

--- a/src/settings/global_settings.rs
+++ b/src/settings/global_settings.rs
@@ -136,7 +136,7 @@ impl From<Properties> for BoosterMainBoardData {
         let mut identifier = [0u8; 23];
 
         let id_bytes = props.id.as_bytes();
-        identifier[..id_bytes.len()].copy_from_slice(&id_bytes);
+        identifier[..id_bytes.len()].copy_from_slice(id_bytes);
 
         BoosterMainBoardData {
             version: EXPECTED_VERSION,


### PR DESCRIPTION
This PR refactors the serial port menu to use `menu`, which implements a lot of the things we want without having to maintain them here.

Ultimately, it may be nice to abstract the various concepts here to make this menu usable in Stabilizer as well and reduce some of the redundant code.

```
PS C:\Users\rsummers> python -m serial COM14
--- Miniterm on COM14  9600,8,N,1 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
> help
AVAILABLE ITEMS:
  reset
  dfu
  service
  read [ <property> ]
  write <property> <value>
  help [ <command> ]

> help read
SUMMARY:
  read [ <property> ]

PARAMETERS:
  <property>
    The name of the property to read. If not specified, all properties are read



DESCRIPTION:
Read a property from the device:

Available Properties:
* id: The MQTT ID of the device
* mac: The MAC address of the device
* broker: The MQTT broker IP address
* gateway: The internet gateway address (Unused when DHCP is enabled)
* ip: The static IP address of Booster (0.0.0.0 indicates DHCP usage)
* netmask: The netmask to use when DHCP is disabled
* fan_speed: The duty cycle of fans when channels are enabled

> help write
SUMMARY:
  write <property> <value>

PARAMETERS:
  <property>
    The name of the property to write: [broker, gateway, ip, netmask, id, fan_speed]

  <value>
    Specifies the value to be written to the property. The format of the value depends on the property to be written.



DESCRIPTION:
Updates the value of a property on the device.

Notes:
* Netmasks must contain only leading data. E.g. 255.255.0.0
* Fan speeds specify the default fan speed duty cycle, and is specified as [0, 1.0]
* MQTT client IDs must be 23 or less ASCII characters.

Examples:
    # Use DHCP for IP address allocation
    write ip "0.0.0.0"

    # Set fans to 45% duty cycle
    write fan_speed 0.45

    # Update the Booster MQTT ID
    write id "my-booster-01"

> read
ip                  : "0.0.0.0"
netmask             : "254.0.0.0"
gateway             : "10.35.20.1"
broker              : "10.35.20.1"
fan_speed           : 0.0
id                  : "80-1f-12-66-60-1b"
mac                 : 80-1f-12-66-60-1b

>
```