### PR TITLE
Updating settings to use sequential-storage, bumping minimq and other deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "mcp3221",
  "microchip-24aa02e48",
  "miniconf",
+ "miniconf_mqtt",
  "minimq",
  "minireq",
  "mono-clock",
@@ -143,11 +144,12 @@ dependencies = [
  "rtic-sync",
  "rtt-logger",
  "rtt-target",
+ "sequential-storage",
  "serde",
  "serde-json-core",
  "serde_with",
  "serial-settings",
- "shared-bus 0.3.1",
+ "shared-bus",
  "smlang",
  "smoltcp-nal",
  "stm32f4xx-hal",
@@ -463,11 +465,10 @@ dependencies = [
 
 [[package]]
 name = "embedded-nal"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447416d161ba378782c13e82b11b267d6d2104b4913679a7c5640e7e94f96ea7"
+checksum = "b8a943fad5ed3d3f8a00f1e80f6bba371f1e7f0df28ec38477535eb318dc19cc"
 dependencies = [
- "heapless 0.7.17",
  "nb 1.1.0",
  "no-std-net 0.6.0",
 ]
@@ -865,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "menu"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5208bd660042c7760f40d960ba0b1a9dc7a9c90775bea4c4637c3b666d2b53d"
+checksum = "ce98110899b3b97775dd181d9088ebee9abcb6804bb7ead4e9450c1f5419562d"
 
 [[package]]
 name = "microchip-24aa02e48"
@@ -878,40 +879,52 @@ dependencies = [
 
 [[package]]
 name = "miniconf"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df2d7bdba3acb28460c347b21e1e88d869f2716ebe060eb6a79f7b76b57de72"
+checksum = "eb5c0319f66b92ee813d7f90b25018673a5e41148caf28951ad0bb9110627b37"
 dependencies = [
- "embedded-io",
- "heapless 0.7.17",
  "itoa",
- "log",
  "miniconf_derive",
- "minimq",
+ "postcard",
  "serde",
  "serde-json-core",
- "smlang",
 ]
 
 [[package]]
 name = "miniconf_derive"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f46d25f40e41f552d76b8eb9e225fe493ebf978a5c3f42b7599e45cfe6b4e3"
+checksum = "47bdb0160aff6c513c43d8ec1188491aedc875eb5cd34abc6cc3d02aab208a5e"
 dependencies = [
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
 ]
 
 [[package]]
-name = "minimq"
-version = "0.8.0"
+name = "miniconf_mqtt"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b561c2c86a3509f7c514f546fb24755753a30fdcf67cce8d5f2f38688483cd31"
+checksum = "a1ab8296f329390df0d4542fd83a42985fefffbbf7fe69dd21f88f2c0c91f5f8"
+dependencies = [
+ "embedded-io",
+ "heapless 0.8.0",
+ "log",
+ "miniconf",
+ "minimq",
+ "serde-json-core",
+ "smlang",
+]
+
+[[package]]
+name = "minimq"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c63955f174d014ef627e6f21dda747c24a294be94234e91ae30a9b2173784e1"
 dependencies = [
  "bit_field",
- "embedded-nal 0.7.0",
+ "embedded-nal 0.8.0",
  "embedded-time",
  "heapless 0.7.17",
  "num_enum",
@@ -923,8 +936,7 @@ dependencies = [
 [[package]]
 name = "minireq"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249c23889cc6d50d796d5fbef033ba7698e6d011c32338eddc4e9ce6b86b3c52"
+source = "git+https://github.com/quartiq/minireq?branch=feature/version-bumps#16bc5f860c4e84dd194fd1d3e0fb1d7c2f83e981"
 dependencies = [
  "embedded-io",
  "heapless 0.7.17",
@@ -945,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "nanorand"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 
 [[package]]
 name = "nb"
@@ -1322,6 +1334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "sequential-storage"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9294c2c7c725835fa69d5a144a29078159360bdc53593e5e977abf8d200f46"
+dependencies = [
+ "embedded-storage",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,22 +1399,13 @@ dependencies = [
 [[package]]
 name = "serial-settings"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/stabilizer#3529c1b13345cd341a3af04b11fd28cdba7af016"
+source = "git+https://github.com/quartiq/stabilizer#6b28ad12b42598a5a54005e3b5a21b27ecc05d06"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",
  "menu",
  "miniconf",
-]
-
-[[package]]
-name = "shared-bus"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b60428415b23ed3f0e3abc776e10e548cf2cbb4288e73d5d181a02b5a90b95"
-dependencies = [
- "cortex-m 0.6.7",
- "embedded-hal 0.2.7",
+ "yafnv",
 ]
 
 [[package]]
@@ -1430,28 +1442,28 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2e3a36ac8fea7b94e666dfa3871063d6e0a5c9d5d4fec9a1a6b7b6760f0229"
+checksum = "5a1a996951e50b5971a2c8c0fa05a381480d70a933064245c4a223ddc87ccc97"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "heapless 0.7.17",
+ "heapless 0.8.0",
  "managed",
 ]
 
 [[package]]
 name = "smoltcp-nal"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd2ed2f8e7643a170506863ed0f52ad1dc5762abdcff27de825dde14fc8025f"
+checksum = "c3ac46812539eefac6ffe76393317b6dd4851fef6f31621cce27e9924d586570"
 dependencies = [
- "embedded-nal 0.7.0",
+ "embedded-nal 0.8.0",
  "embedded-time",
  "heapless 0.7.17",
  "nanorand",
- "shared-bus 0.2.2",
+ "shared-bus",
  "smoltcp",
 ]
 
@@ -1706,4 +1718,13 @@ dependencies = [
  "embedded-hal 0.2.7",
  "embedded-nal 0.6.0",
  "nb 1.1.0",
+]
+
+[[package]]
+name = "yafnv"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a163032c49aec712809692a0b0b49842b0bc49b05d79d9c6dff41ccd93aa1b"
+dependencies = [
+ "num-traits",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -935,11 +936,12 @@ dependencies = [
 
 [[package]]
 name = "minireq"
-version = "0.3.0"
-source = "git+https://github.com/quartiq/minireq?branch=feature/version-bumps#16bc5f860c4e84dd194fd1d3e0fb1d7c2f83e981"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64600b540ee248a33ecae6fe10c65b53ae06255c3cb5afc894a608dc8b15749d"
 dependencies = [
  "embedded-io",
- "heapless 0.7.17",
+ "heapless 0.8.0",
  "log",
  "minimq",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ miniconf_mqtt = "0.11"
 minimq = "0.9.0"
 w5500 = "0.4.1"
 smlang= "0.6"
-minireq = { git = "https://github.com/quartiq/minireq", branch = "feature/version-bumps" }
+minireq = "0.4"
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "2.0", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cortex-m = "0.7.7"
 cortex-m-rt = "0.7"
 fugit = "0.3"
 rtic-sync = "1"
+sequential-storage = "0.6"
 rtic = {version = "2.1", features = ["thumbv7-backend"] }
 rtic-monotonics = { version = "1.5", features = ["cortex-m-systick"] }
 rand_core = "0.6"
@@ -51,16 +52,17 @@ usbd-serial = "0.2.2"
 encdec = { version = "0.9", default-features = false }
 crc-any = { version = "2.4.4", default-features = false }
 panic-persist = { version = "0.3", features = ["custom-panic-handler", "utf8"] }
-miniconf = { version = "0.9.0", features = ["mqtt-client"]}
+miniconf = { version = "0.11.0", features = ["json-core", "derive", "postcard"]}
+miniconf_mqtt = "0.11"
 # Note: Keep `py/pyproject.toml` version in sync with the Minimq version used in FW.
-minimq = "0.8.0"
+minimq = "0.9.0"
 w5500 = "0.4.1"
 smlang= "0.6"
-minireq = "0.3.0"
+minireq = { git = "https://github.com/quartiq/minireq", branch = "feature/version-bumps" }
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "2.0", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }
-smoltcp-nal = { version = "0.4", features=["shared-stack"] }
+smoltcp-nal = { version = "0.5", features=["shared-stack"] }
 
 serial-settings = {git = "https://github.com/quartiq/stabilizer"}
 postcard = "1"

--- a/memory.x
+++ b/memory.x
@@ -1,8 +1,8 @@
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  /* Note: The last 128KB flash sector is reserved for settings storage. */
-  FLASH : ORIGIN = 0x08000000, LENGTH = 896K
+  /* Note: The last 256KB flash sector is reserved for settings storage. */
+  FLASH : ORIGIN = 0x08000000, LENGTH = 768K
   RAM : ORIGIN = 0x20000000, LENGTH = 127K
   PANDUMP : ORIGIN = 0x2001FC00, LENGTH = 1K
 }

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -13,6 +13,10 @@ impl Flash {
             flash,
         }
     }
+
+    pub fn range(&self) -> core::ops::Range<u32> {
+        0..(self.capacity() as u32)
+    }
 }
 
 impl embedded_storage::nor_flash::ErrorType for Flash {
@@ -27,7 +31,7 @@ impl embedded_storage::nor_flash::ReadNorFlash for Flash {
     }
 
     fn capacity(&self) -> usize {
-        self.flash.capacity()
+        self.flash.capacity() - (self.base as usize)
     }
 }
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -14,7 +14,6 @@ pub mod metadata;
 pub mod net_interface;
 pub mod platform;
 pub mod rf_channel;
-pub mod serial_terminal;
 pub mod setup;
 pub mod usb;
 pub mod user_interface;
@@ -44,7 +43,8 @@ pub enum Mac {
     Enc424j600(enc424j600::Enc424j600<Spi, SpiCs>),
 }
 
-pub type SerialTerminal = serial_settings::Runner<'static, serial_terminal::SerialSettingsPlatform>;
+pub type SerialTerminal =
+    serial_settings::Runner<'static, crate::settings::flash::SerialSettingsPlatform, 1>;
 
 pub type NetworkStack = smoltcp_nal::NetworkStack<'static, Mac, SystemTimer>;
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -289,8 +289,15 @@ pub fn setup(
         mac
     };
 
+    let mut flash = {
+        let flash = stm32f4xx_hal::flash::LockedFlash::new(device.FLASH);
+        const SECTOR_SIZE: usize = 128 * 1024;
+        Flash::new(flash, 6 * SECTOR_SIZE)
+    };
+
     // Read the EUI48 identifier and configure the ethernet MAC address.
     let mut settings = BoosterSettings::new(eeprom);
+    crate::settings::flash::load_from_flash(&mut settings.properties, &mut flash);
 
     let mut mac = {
         let mut spi = {
@@ -487,20 +494,11 @@ pub fn setup(
     };
 
     let serial_terminal = {
-        let mut flash = {
-            let flash = stm32f4xx_hal::flash::LockedFlash::new(device.FLASH);
-            const SECTOR_SIZE: usize = 128 * 1024;
-            Flash::new(flash, 7 * SECTOR_SIZE)
-        };
-
-        // Attempt to load flash settings
-        settings.properties.reload(&mut flash);
-
         let input_buffer = cortex_m::singleton!(:[u8; 256] = [0u8; 256]).unwrap();
         let serialize_buffer = cortex_m::singleton!(:[u8; 512] = [0u8; 512]).unwrap();
 
         serial_settings::Runner::new(
-            super::serial_terminal::SerialSettingsPlatform {
+            crate::settings::flash::SerialSettingsPlatform {
                 metadata,
                 interface: serial_settings::BestEffortInterface::new(usb_serial),
                 storage: flash,
@@ -508,6 +506,7 @@ pub fn setup(
             },
             input_buffer,
             serialize_buffer,
+            &mut settings.properties,
         )
         .unwrap()
     };

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -292,7 +292,11 @@ pub fn setup(
     let mut flash = {
         let flash = stm32f4xx_hal::flash::LockedFlash::new(device.FLASH);
         const SECTOR_SIZE: usize = 128 * 1024;
-        Flash::new(flash, 6 * SECTOR_SIZE)
+        const NUM_SECTORS: usize = 8;
+
+        // sequential-storage requires 2 flash sectors for storage. We allocate them at the end of
+        // flash.
+        Flash::new(flash, (NUM_SECTORS - 2) * SECTOR_SIZE)
     };
 
     // Read the EUI48 identifier and configure the ethernet MAC address.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use hardware::{
     Channel, SerialTerminal, SystemTimer, Systick,
 };
 
+use settings::global_settings::BoosterMainBoardData;
 use settings::runtime_settings::RuntimeSettings;
 use watchdog::{WatchdogClient, WatchdogManager};
 
@@ -53,6 +54,7 @@ mod app {
         main_bus: MainBus,
         net_devices: net::NetworkDevices,
         watchdog: WatchdogManager,
+        runtime_settings: RuntimeSettings,
     }
 
     #[local]
@@ -61,6 +63,7 @@ mod app {
         leds: UserLeds,
         usb: UsbDevice,
         usb_terminal: SerialTerminal,
+        global_settings: BoosterMainBoardData,
     }
 
     #[init]
@@ -97,13 +100,14 @@ mod app {
                     &booster.settings.properties.broker,
                     booster.network_stack,
                     &booster.settings.properties.id,
-                    settings,
                     clock,
                     booster.metadata,
                 ),
                 watchdog: watchdog_manager,
+                runtime_settings: settings,
             },
             LocalResources {
+                global_settings: booster.settings.properties,
                 buttons: booster.buttons,
                 leds: booster.leds,
                 usb: booster.usb_device,
@@ -219,19 +223,14 @@ mod app {
         }
     }
 
-    #[task(priority = 1, shared=[net_devices, main_bus])]
+    #[task(priority = 1, shared=[net_devices, main_bus, runtime_settings])]
     async fn update_settings(mut c: update_settings::Context) {
-        let all_settings = c
-            .shared
-            .net_devices
-            .lock(|net_devices| net_devices.settings.settings().clone());
-
         for idx in enum_iterator::all::<Channel>() {
-            c.shared.main_bus.lock(|main_bus| {
+            (&mut c.shared.main_bus, &mut c.shared.runtime_settings).lock(|main_bus, settings| {
                 main_bus
                     .channels
                     .channel_mut(idx)
-                    .zip(all_settings.channel[idx as usize].as_ref().as_ref())
+                    .zip(settings.channel[idx as usize].as_ref().as_ref())
                     .map(|((channel, _), settings)| {
                         channel.handle_settings(settings).unwrap_or_else(|err| {
                             log::warn!("Settings failure on {:?}: {:?}", idx, err)
@@ -241,19 +240,20 @@ mod app {
         }
 
         // Update the fan speed.
-        c.shared
-            .main_bus
-            .lock(|main_bus| main_bus.fans.set_default_duty_cycle(all_settings.fan_speed));
+        (&mut c.shared.main_bus, &mut c.shared.runtime_settings)
+            .lock(|main_bus, settings| main_bus.fans.set_default_duty_cycle(settings.fan_speed));
 
         // Update the telemetry rate.
-        c.shared.net_devices.lock(|net_devices| {
-            net_devices
-                .telemetry
-                .set_telemetry_period(all_settings.telemetry_period)
-        });
+        (&mut c.shared.net_devices, &mut c.shared.runtime_settings).lock(
+            |net_devices, settings| {
+                net_devices
+                    .telemetry
+                    .set_telemetry_period(settings.telemetry_period)
+            },
+        );
     }
 
-    #[task(priority = 2, shared=[watchdog], local=[usb, usb_terminal])]
+    #[task(priority = 2, shared=[watchdog], local=[usb, usb_terminal, global_settings])]
     async fn usb(mut c: usb::Context) {
         loop {
             // Check in with the watchdog.
@@ -262,7 +262,10 @@ mod app {
                 .lock(|watchdog| watchdog.check_in(WatchdogClient::Usb));
 
             c.local.usb.process(c.local.usb_terminal);
-            c.local.usb_terminal.process().unwrap();
+            c.local
+                .usb_terminal
+                .process(c.local.global_settings)
+                .unwrap();
 
             // Process any log output.
             LOGGER.process(c.local.usb_terminal);
@@ -272,7 +275,7 @@ mod app {
         }
     }
 
-    #[idle(shared=[main_bus, net_devices, watchdog])]
+    #[idle(shared=[main_bus, net_devices, watchdog, runtime_settings])]
     fn idle(mut c: idle::Context) -> ! {
         loop {
             // Check in with the watchdog.
@@ -280,30 +283,20 @@ mod app {
                 .watchdog
                 .lock(|watchdog| watchdog.check_in(WatchdogClient::Idle));
 
+            // TODO: Handle out-of-range settings
             // Handle the Miniconf settings interface.
-            let mut republish = false;
-            match c.shared.net_devices.lock(|net| {
-                net.settings.handled_update(|path, old, new| {
-                    let result = RuntimeSettings::handle_update(path, old, new);
-                    if result.is_err() {
-                        republish = true;
-                    }
-                    result
-                })
-            }) {
-                Ok(true) => update_settings::spawn().unwrap(),
+            match (&mut c.shared.net_devices, &mut c.shared.runtime_settings)
+                .lock(|net, runtime_settings| net.settings_client.update(runtime_settings))
+            {
+                Ok(true) => {
+                    update_settings::spawn().unwrap();
+                }
                 Ok(false) => {}
                 Err(minimq::Error::Network(smoltcp_nal::NetworkError::TcpConnectionFailure(
                     smoltcp_nal::smoltcp::socket::tcp::ConnectError::Unaddressable,
                 ))) => {}
                 other => log::warn!("Miniconf update failure: {:?}", other),
-            }
-
-            if republish {
-                c.shared
-                    .net_devices
-                    .lock(|net| net.settings.force_republish());
-            }
+            };
 
             // Handle the MQTT control interface.
             let main_bus = &mut c.shared.main_bus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,7 +283,6 @@ mod app {
                 .watchdog
                 .lock(|watchdog| watchdog.check_in(WatchdogClient::Idle));
 
-            // TODO: Handle out-of-range settings
             // Handle the Miniconf settings interface.
             match (&mut c.shared.net_devices, &mut c.shared.runtime_settings)
                 .lock(|net, runtime_settings| net.settings_client.update(runtime_settings))

--- a/src/settings/channel_settings.rs
+++ b/src/settings/channel_settings.rs
@@ -1,7 +1,9 @@
 //! Booster NGFW NVM channel settings
 
 use super::{SemVersion, SinaraBoardId, SinaraConfiguration};
-use crate::{hardware::I2cProxy, linear_transformation::LinearTransformation, Error};
+use crate::{
+    hardware::platform, hardware::I2cProxy, linear_transformation::LinearTransformation, Error,
+};
 use encdec::{Decode, DecodeOwned, Encode};
 use enum_iterator::Sequence;
 use microchip_24aa02e48::Microchip24AA02E48;
@@ -72,7 +74,9 @@ impl DecodeOwned for ChannelState {
 /// Represents booster channel-specific configuration values.
 #[derive(Tree, Encode, DecodeOwned, Debug, Copy, Clone, PartialEq)]
 pub struct ChannelSettings {
+    #[tree(validate=Self::validate_output_interlock)]
     pub output_interlock_threshold: f32,
+    #[tree(validate=Self::validate_bias_voltage)]
     pub bias_voltage: f32,
     pub state: ChannelState,
     pub input_power_transform: LinearTransformation,
@@ -105,6 +109,31 @@ impl Default for ChannelSettings {
             ),
             input_power_transform: LinearTransformation::new(1.0 / 1.5 / 0.035, -35.6 + 8.9),
         }
+    }
+}
+
+impl ChannelSettings {
+    fn validate_bias_voltage(&mut self, new: f32) -> Result<f32, &'static str> {
+        if (0.0..=platform::BIAS_DAC_VCC).contains(&(-1.0 * new)) {
+            Ok(new)
+        } else {
+            Err("Bias voltage out of range")
+        }
+    }
+
+    fn validate_output_interlock(&mut self, new: f32) -> Result<f32, &'static str> {
+        // Verify the output interlock is within acceptable values.
+        if new >= platform::MAX_OUTPUT_POWER_DBM {
+            return Err("Output interlock threshold too high");
+        }
+
+        // Verify the interlock is mappable to a DAC threshold.
+        let output_interlock_voltage = self.output_power_transform.invert(new);
+        if !(0.00..=ad5627::MAX_VOLTAGE).contains(&output_interlock_voltage) {
+            return Err("Output interlock threshold voltage out of range");
+        }
+
+        Ok(new)
     }
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,6 +1,7 @@
 //! Booster NGFW NVM settings
 
 pub mod channel_settings;
+pub mod flash;
 pub mod global_settings;
 pub mod runtime_settings;
 mod sinara;

--- a/src/settings/runtime_settings.rs
+++ b/src/settings/runtime_settings.rs
@@ -9,7 +9,7 @@ use miniconf::Tree;
 
 #[derive(Clone, Tree)]
 pub struct RuntimeSettings {
-    #[tree(depth(3))]
+    #[tree(depth = 3)]
     pub channel: [Option<ChannelSettings>; 8],
 
     /// The normalized fan speed. 1.0 corresponds to 100% on and 0.0 corresponds to completely

--- a/src/settings/runtime_settings.rs
+++ b/src/settings/runtime_settings.rs
@@ -1,10 +1,7 @@
 //! Booster NGFW runtime settings
 
 use super::channel_settings::ChannelSettings;
-use crate::{
-    hardware::{self, platform, Channel},
-    net,
-};
+use crate::{hardware, net};
 use miniconf::Tree;
 
 #[derive(Clone, Tree)]
@@ -14,6 +11,7 @@ pub struct RuntimeSettings {
 
     /// The normalized fan speed. 1.0 corresponds to 100% on and 0.0 corresponds to completely
     /// off.
+    #[tree(validate=Self::validate_fans)]
     pub fan_speed: f32,
 
     /// The configured telemetry period in seconds.
@@ -31,39 +29,11 @@ impl Default for RuntimeSettings {
 }
 
 impl RuntimeSettings {
-    pub fn handle_update(
-        _: &str,
-        settings: &mut Self,
-        new_settings: &Self,
-    ) -> Result<(), &'static str> {
-        for idx in enum_iterator::all::<Channel>() {
-            if let Some(settings) = new_settings.channel[idx as usize].as_ref() {
-                // Check that the interlock thresholds are sensible.
-                if settings.output_interlock_threshold > platform::MAX_OUTPUT_POWER_DBM {
-                    return Err("Interlock threshold too high");
-                }
-
-                // Validate bias voltage.
-                if !(0.0..=platform::BIAS_DAC_VCC).contains(&(-1.0 * settings.bias_voltage)) {
-                    return Err("Bias voltage out of range");
-                }
-
-                // Validate that the output interlock threshold voltage (after mapping) is actually
-                // configurable on the DAC.
-                let output_interlock_voltage = settings
-                    .output_power_transform
-                    .invert(settings.output_interlock_threshold);
-                if !(0.00..=ad5627::MAX_VOLTAGE).contains(&output_interlock_voltage) {
-                    return Err("Output interlock threshold voltage out of range");
-                }
-            }
+    fn validate_fans(&mut self, new: f32) -> Result<f32, &'static str> {
+        if (0.0..=1.0).contains(&new) {
+            Ok(new)
+        } else {
+            Err("Invalid fan speed. Must be within range [0, 1.0]")
         }
-
-        if !(0.0..=1.0).contains(&new_settings.fan_speed) {
-            return Err("Invalid fan speed");
-        }
-
-        *settings = new_settings.clone();
-        Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes #399 

This PR updates the firmware to utilize `sequential-storage` for keeping settings in flash as opposed to using a single binary blob. This enables us to expand and modify the settings structure going forwards.

This PR also updates various MQTT-related dependencies to the latest versions.

TODO:
- [x] Publish new version of minireq