### PR TITLE
Refactoring settings to enable USB control of runtime-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The broker can now be specified using DNS
 * Updated to RTIC v2 and async support. MSRV bumped to 1.75.0
 * All settings, including RF channel settings, are now exposed via the USB interface
+    * This means that MQTT is no longer required for basic device operation. Any settings saved on
+    the device will remain there, but newer settings saved via the USB interface will be stored in
+    mainboard flash and will overwrite EEPROM-based settings during device boot. Reversion to older
+    firmware variants will still be able to use existing EEPROM settings, but the EEPROM contents
+    are no longer modified when settings are changed.
 
 ## [0.5.0] - 03-07-2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Serial terminal replaced with `menu` for simplicity
 * The broker can now be specified using DNS
 * Updated to RTIC v2 and async support. MSRV bumped to 1.75.0
+* All settings, including RF channel settings, are now exposed via the USB interface
 
 ## [0.5.0] - 03-07-2023
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "serial-settings"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/stabilizer?rev=60ffea60f#60ffea60fe7b4933eff5faa2c75bf947ddbfe2c6"
+source = "git+https://github.com/quartiq/stabilizer?rev=c8beb2eee#c8beb2eeeb2ec0eb097c186db0492129df521064"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "serial-settings"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/stabilizer#6b28ad12b42598a5a54005e3b5a21b27ecc05d06"
+source = "git+https://github.com/quartiq/stabilizer?rev=60ffea60f#60ffea60fe7b4933eff5faa2c75bf947ddbfe2c6"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "serial-settings"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/stabilizer?rev=c8beb2eee#c8beb2eeeb2ec0eb097c186db0492129df521064"
+source = "git+https://github.com/quartiq/stabilizer?rev=58bc7da18#58bc7da183c338dbe79663a74b6c0d992a31b6f3"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }
 smoltcp-nal = { version = "0.5", features=["shared-stack"] }
 
-serial-settings = {git = "https://github.com/quartiq/stabilizer", rev= "60ffea60f"}
+serial-settings = {git = "https://github.com/quartiq/stabilizer", rev= "c8beb2eee"}
 postcard = "1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,8 @@ enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }
 smoltcp-nal = { version = "0.5", features=["shared-stack"] }
 
-serial-settings = {git = "https://github.com/quartiq/stabilizer", rev= "c8beb2eee"}
+serial-settings = {git = "https://github.com/quartiq/stabilizer", rev = "58bc7da18"}
+
 postcard = "1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }
 smoltcp-nal = { version = "0.5", features=["shared-stack"] }
 
-serial-settings = {git = "https://github.com/quartiq/stabilizer"}
+serial-settings = {git = "https://github.com/quartiq/stabilizer", rev= "60ffea60f"}
 postcard = "1"
 
 [build-dependencies]

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -44,7 +44,7 @@ pub enum Mac {
 }
 
 pub type SerialTerminal =
-    serial_settings::Runner<'static, crate::settings::flash::SerialSettingsPlatform, 1>;
+    serial_settings::Runner<'static, crate::settings::flash::SerialSettingsPlatform, 5>;
 
 pub type NetworkStack = smoltcp_nal::NetworkStack<'static, Mac, SystemTimer>;
 
@@ -54,6 +54,9 @@ pub type I2cError = hal::i2c::Error;
 
 pub type UsbBus = hal::otg_fs::UsbBus<hal::otg_fs::USB>;
 pub type Eeprom = microchip_24aa02e48::Microchip24AA02E48<I2C2>;
+
+pub type SerialPort =
+    usbd_serial::SerialPort<'static, crate::hardware::UsbBus, &'static mut [u8], &'static mut [u8]>;
 
 /// Indicates a booster RF channel.
 #[derive(Sequence, Copy, Clone, Debug, Serialize, Deserialize)]

--- a/src/hardware/net_interface.rs
+++ b/src/hardware/net_interface.rs
@@ -1,6 +1,5 @@
 //! Smoltcp network storage and configuration
 
-use crate::BoosterSettings;
 use smoltcp_nal::smoltcp;
 
 use super::Mac;
@@ -56,7 +55,7 @@ impl TcpSocketStorage {
 /// * `random_seed` - A random seed for the network stack.
 pub fn setup(
     device: &mut Mac,
-    settings: &BoosterSettings,
+    settings: &crate::settings::Settings,
     random_seed: u64,
 ) -> (
     smoltcp::iface::Interface,
@@ -64,11 +63,10 @@ pub fn setup(
 ) {
     let net_store = cortex_m::singleton!(: NetStorage = NetStorage::new()).unwrap();
 
-    let ip_address = settings.properties.ip_cidr();
+    let ip_address = settings.ip_cidr();
 
-    let mut config = smoltcp::iface::Config::new(smoltcp::wire::HardwareAddress::Ethernet(
-        settings.properties.mac,
-    ));
+    let mut config =
+        smoltcp::iface::Config::new(smoltcp::wire::HardwareAddress::Ethernet(settings.mac));
     config.random_seed = random_seed;
 
     let mut interface =
@@ -76,7 +74,7 @@ pub fn setup(
 
     interface
         .routes_mut()
-        .add_default_ipv4_route(settings.properties.gateway.0)
+        .add_default_ipv4_route(settings.gateway.0)
         .unwrap();
 
     let mut sockets = smoltcp::iface::SocketSet::new(&mut net_store.sockets[..]);

--- a/src/hardware/net_interface.rs
+++ b/src/hardware/net_interface.rs
@@ -63,8 +63,6 @@ pub fn setup(
 ) {
     let net_store = cortex_m::singleton!(: NetStorage = NetStorage::new()).unwrap();
 
-    let ip_address = settings.ip_cidr();
-
     let mut config =
         smoltcp::iface::Config::new(smoltcp::wire::HardwareAddress::Ethernet(settings.mac));
     config.random_seed = random_seed;
@@ -94,10 +92,10 @@ pub fn setup(
         &mut net_store.dns_storage[..],
     ));
 
-    if ip_address.address().is_unspecified() {
+    if settings.ip.0.address().is_unspecified() {
         sockets.add(smoltcp::socket::dhcpv4::Socket::new());
     } else {
-        interface.update_ip_addrs(|addrs| addrs.push(ip_address).unwrap());
+        interface.update_ip_addrs(|addrs| addrs.push(settings.ip.0.into()).unwrap());
     }
 
     (interface, sockets)

--- a/src/hardware/rf_channel.rs
+++ b/src/hardware/rf_channel.rs
@@ -10,9 +10,7 @@ use minimq::embedded_time::{duration::Extensions, Clock, Instant};
 
 use super::{delay::AsmDelay, platform, I2cBusManager, I2cProxy, SystemTimer};
 use crate::{
-    settings::{
-        channel_settings::ChannelSettings, channel_settings::ChannelState, BoosterChannelSettings,
-    },
+    settings::eeprom::rf_channel::{BoosterChannelSettings, ChannelSettings, ChannelState},
     Error,
 };
 use stm32f4xx_hal::{

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use stm32f4xx_hal::hal_02::blocking::delay::DelayMs;
 
-use crate::settings::eeprom::main_board::BoosterSettings;
+use crate::settings::eeprom::main_board::BoosterMainBoardData;
 
 use stm32f4xx_hal as hal;
 
@@ -311,12 +311,7 @@ pub fn setup(
             settings
         };
 
-        let eeprom_settings = {
-            // TODO: No need to store the EEPROM with the BoosterSettings anymore. We just want to
-            // load the mainboard data from EEPROM as the initial values.
-            let settings = BoosterSettings::new(eeprom);
-            settings.properties
-        };
+        let eeprom_settings = BoosterMainBoardData::load(&mut eeprom);
 
         let mut settings = crate::settings::Settings {
             mac: eeprom_settings.mac,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -10,12 +10,12 @@ use super::{
     rf_channel::{AdcPin, ChannelPins as RfChannelPins},
     usb,
     user_interface::{UserButtons, UserLeds},
-    HardwareVersion, Mac, NetworkStack, SerialTerminal, SystemTimer, Systick, UsbBus, CPU_FREQ,
-    I2C,
+    Channel, HardwareVersion, Mac, NetworkStack, SerialTerminal, SystemTimer, Systick, UsbBus,
+    CPU_FREQ, I2C,
 };
 use stm32f4xx_hal::hal_02::blocking::delay::DelayMs;
 
-use crate::settings::BoosterSettings;
+use crate::settings::eeprom::main_board::BoosterSettings;
 
 use stm32f4xx_hal as hal;
 
@@ -82,7 +82,7 @@ pub struct BoosterDevices {
     pub watchdog: hal::watchdog::IndependentWatchdog,
     pub usb_device: usb::UsbDevice,
     pub usb_serial: SerialTerminal,
-    pub settings: BoosterSettings,
+    pub settings: crate::settings::Settings,
     pub metadata: &'static ApplicationMetadata,
 }
 
@@ -199,7 +199,7 @@ pub fn setup(
 
     // Instantiate the I2C interface to the I2C mux. Use a shared-bus so we can share the I2C
     // bus with all of the Booster peripheral devices.
-    let channels = {
+    let mut channels = {
         let pins = [
             channel_pins!(gpiod, gpioe, gpiog, pd0, pd8, pe8, pe0, pg8, gpioa, pa0, pa1),
             channel_pins!(gpiod, gpioe, gpiog, pd1, pd9, pe9, pe1, pg9, gpioa, pa2, pa3),
@@ -300,8 +300,37 @@ pub fn setup(
     };
 
     // Read the EUI48 identifier and configure the ethernet MAC address.
-    let mut settings = BoosterSettings::new(eeprom);
-    crate::settings::flash::load_from_flash(&mut settings.properties, &mut flash);
+    let mut settings = {
+        let runtime_settings = {
+            let mut settings = crate::settings::runtime_settings::RuntimeSettings::default();
+            for idx in enum_iterator::all::<Channel>() {
+                settings.channel[idx as usize] = channels
+                    .channel_mut(idx)
+                    .map(|(channel, _)| *channel.context().settings())
+            }
+            settings
+        };
+
+        let eeprom_settings = {
+            // TODO: No need to store the EEPROM with the BoosterSettings anymore. We just want to
+            // load the mainboard data from EEPROM as the initial values.
+            let settings = BoosterSettings::new(eeprom);
+            settings.properties
+        };
+
+        let mut settings = crate::settings::Settings {
+            mac: eeprom_settings.mac,
+            ip: eeprom_settings.ip,
+            broker: eeprom_settings.broker,
+            gateway: eeprom_settings.gateway,
+            netmask: eeprom_settings.netmask,
+            id: eeprom_settings.id,
+            booster: runtime_settings,
+        };
+
+        crate::settings::flash::load_from_flash(&mut settings, &mut flash);
+        settings
+    };
 
     let mut mac = {
         let mut spi = {
@@ -434,7 +463,7 @@ pub fn setup(
         ChassisFans::new(
             [fan1, fan2, fan3],
             main_board_leds,
-            settings.properties.fan_speed,
+            settings.booster.fan_speed,
         )
     };
 
@@ -461,8 +490,14 @@ pub fn setup(
         );
 
         usb_bus.replace(hal::otg_fs::UsbBus::new(usb, &mut endpoint_memory[..]));
+        let read_store = cortex_m::singleton!(: [u8; 128] = [0; 128]).unwrap();
+        let write_store = cortex_m::singleton!(: [u8; 1024] = [0; 1024]).unwrap();
 
-        let usb_serial = usbd_serial::SerialPort::new(usb_bus.as_ref().unwrap());
+        let usb_serial = usbd_serial::SerialPort::new_with_store(
+            usb_bus.as_ref().unwrap(),
+            &mut read_store[..],
+            &mut write_store[..],
+        );
 
         // Generate a device serial number from the MAC address.
         {
@@ -506,11 +541,10 @@ pub fn setup(
                 metadata,
                 interface: serial_settings::BestEffortInterface::new(usb_serial),
                 storage: flash,
-                settings: settings.properties.clone(),
             },
             input_buffer,
             serialize_buffer,
-            &mut settings.properties,
+            &mut settings,
         )
         .unwrap()
     };

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -299,33 +299,33 @@ pub fn setup(
         Flash::new(flash, (NUM_SECTORS - 2) * SECTOR_SIZE)
     };
 
-    // Read the EUI48 identifier and configure the ethernet MAC address.
-    let mut settings = {
-        let runtime_settings = {
-            let mut settings = crate::settings::runtime_settings::RuntimeSettings::default();
-            for idx in enum_iterator::all::<Channel>() {
-                settings.channel[idx as usize] = channels
-                    .channel_mut(idx)
-                    .map(|(channel, _)| *channel.context().settings())
-            }
-            settings
-        };
+    // Load initial runtime setings from RF channel EEPROM. We'll potentially overwrite these with
+    // data loaded from flash later.
+    let mut runtime_settings = crate::settings::runtime_settings::RuntimeSettings::default();
+    for idx in enum_iterator::all::<Channel>() {
+        runtime_settings.channel[idx as usize] = channels
+            .channel_mut(idx)
+            .map(|(channel, _)| *channel.context().settings())
+    }
 
-        let eeprom_settings = BoosterMainBoardData::load(&mut eeprom);
+    // Load initial main-board settings from EEPROM
+    let eeprom_settings = BoosterMainBoardData::load(&mut eeprom);
+    runtime_settings.fan_speed = eeprom_settings.fan_speed;
 
-        let mut settings = crate::settings::Settings {
-            mac: eeprom_settings.mac,
-            ip: eeprom_settings.ip,
-            broker: eeprom_settings.broker,
-            gateway: eeprom_settings.gateway,
-            netmask: eeprom_settings.netmask,
-            id: eeprom_settings.id,
-            booster: runtime_settings,
-        };
-
-        crate::settings::flash::load_from_flash(&mut settings, &mut flash);
-        settings
+    let mut settings = crate::settings::Settings {
+        mac: eeprom_settings.mac,
+        ip: eeprom_settings.ip,
+        broker: eeprom_settings.broker,
+        gateway: eeprom_settings.gateway,
+        id: eeprom_settings.id,
+        booster: runtime_settings,
     };
+
+    // Now that we've initialized settings from EEPROM, we'll potentially overwrite them using
+    // values stored in flash. This helps preserve backwards compatibility with older Booster
+    // firmware versions that didn't store settings in flash. We no longer persist settings to
+    // EEPROM, so flash will have the latest and greatest settings data.
+    crate::settings::flash::load_from_flash(&mut settings, &mut flash);
 
     let mut mac = {
         let mut spi = {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -36,7 +36,7 @@ pub struct NetworkDevices {
     pub telemetry: mqtt_control::TelemetryClient,
     pub settings_client: miniconf_mqtt::MqttClient<
         'static,
-        crate::RuntimeSettings,
+        crate::settings::runtime_settings::RuntimeSettings,
         NetworkStackProxy,
         SystemTimer,
         miniconf_mqtt::minimq::broker::NamedBroker<NetworkStackProxy>,

--- a/src/settings/eeprom/main_board.rs
+++ b/src/settings/eeprom/main_board.rs
@@ -224,18 +224,14 @@ impl BoosterMainBoardData {
     /// * `eui48` - The EUI48 identifier of the booster mainboard.
     pub fn default(eui48: &[u8; 6]) -> Self {
         let mut name: String<23> = String::new();
-        write!(
-            &mut name,
-            "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
-            eui48[0], eui48[1], eui48[2], eui48[3], eui48[4], eui48[5]
-        )
-        .unwrap();
+        let mac = smoltcp_nal::smoltcp::wire::EthernetAddress(*eui48);
+        write!(&mut name, "{}", mac).unwrap();
 
         let mut id: [u8; 23] = [0; 23];
         id[..name.len()].copy_from_slice(name.as_str().as_bytes());
 
         Self {
-            mac: smoltcp_nal::smoltcp::wire::EthernetAddress(*eui48),
+            mac,
             _version: EXPECTED_VERSION,
             ip: "0.0.0.0/0".parse().unwrap(),
             broker: "mqtt".parse().unwrap(),

--- a/src/settings/eeprom/mod.rs
+++ b/src/settings/eeprom/mod.rs
@@ -1,0 +1,21 @@
+pub mod main_board;
+pub mod rf_channel;
+mod sinara;
+
+use encdec::{Decode, DecodeOwned, Encode};
+use serde::{Deserialize, Serialize};
+
+/// A semantic version control for recording software versions.
+#[derive(Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+pub struct SemVersion {
+    major: u8,
+    minor: u8,
+    patch: u8,
+}
+
+impl SemVersion {
+    /// Determine if this version is compatible with `rhs`.
+    pub fn is_compatible_with(&self, rhs: &SemVersion) -> bool {
+        (self.major == rhs.major) && (self.minor <= rhs.minor)
+    }
+}

--- a/src/settings/eeprom/mod.rs
+++ b/src/settings/eeprom/mod.rs
@@ -7,9 +7,7 @@ use encdec::{Decode, DecodeOwned, Encode};
 use serde::{Deserialize, Serialize};
 
 /// A semantic version control for recording software versions.
-#[derive(
-    Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone,
-)]
+#[derive(Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 pub struct SemVersion {
     major: u8,
     minor: u8,

--- a/src/settings/eeprom/mod.rs
+++ b/src/settings/eeprom/mod.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// A semantic version control for recording software versions.
 #[derive(
-    Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, PartialOrd, Eq, Copy, Clone,
+    Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone,
 )]
 pub struct SemVersion {
     major: u8,
@@ -20,6 +20,12 @@ impl SemVersion {
     /// Determine if this version is compatible with `rhs`.
     pub fn is_compatible_with(&self, rhs: &SemVersion) -> bool {
         self.major == rhs.major
+    }
+}
+
+impl core::cmp::PartialOrd for SemVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/settings/eeprom/mod.rs
+++ b/src/settings/eeprom/mod.rs
@@ -2,11 +2,14 @@ pub mod main_board;
 pub mod rf_channel;
 mod sinara;
 
+use core::cmp::Ordering;
 use encdec::{Decode, DecodeOwned, Encode};
 use serde::{Deserialize, Serialize};
 
 /// A semantic version control for recording software versions.
-#[derive(Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+#[derive(
+    Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, PartialOrd, Eq, Copy, Clone,
+)]
 pub struct SemVersion {
     major: u8,
     minor: u8,
@@ -16,6 +19,22 @@ pub struct SemVersion {
 impl SemVersion {
     /// Determine if this version is compatible with `rhs`.
     pub fn is_compatible_with(&self, rhs: &SemVersion) -> bool {
-        (self.major == rhs.major) && (self.minor <= rhs.minor)
+        self.major == rhs.major
+    }
+}
+
+impl core::cmp::Ord for SemVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.major.cmp(&other.major) {
+            Ordering::Equal => {}
+            other => return other,
+        }
+
+        match self.minor.cmp(&other.minor) {
+            Ordering::Equal => {}
+            other => return other,
+        }
+
+        self.patch.cmp(&other.patch)
     }
 }

--- a/src/settings/eeprom/rf_channel.rs
+++ b/src/settings/eeprom/rf_channel.rs
@@ -1,6 +1,9 @@
 //! Booster NGFW NVM channel settings
 
-use super::{SemVersion, SinaraBoardId, SinaraConfiguration};
+use super::{
+    sinara::{BoardId as SinaraBoardId, SinaraConfiguration},
+    SemVersion,
+};
 use crate::{
     hardware::platform, hardware::I2cProxy, linear_transformation::LinearTransformation, Error,
 };

--- a/src/settings/eeprom/sinara.rs
+++ b/src/settings/eeprom/sinara.rs
@@ -142,7 +142,7 @@ pub struct SinaraConfiguration {
     pub user_data: [u8; 16],
     pub board_data: [u8; 64],
     _padding: [u8; 122],
-    pub eui48: [u8; 6],
+    pub _eui48: [u8; 6],
 }
 
 impl SinaraConfiguration {
@@ -170,7 +170,7 @@ impl SinaraConfiguration {
                 user_data: deserializer.try_take(16)?.try_into().unwrap(),
                 board_data: deserializer.deserialize_board_data()?,
                 _padding: deserializer.deserialize_padding()?,
-                eui48: deserializer.try_take(6)?.try_into().unwrap(),
+                _eui48: deserializer.try_take(6)?.try_into().unwrap(),
             }
         };
 
@@ -241,7 +241,7 @@ impl SinaraConfiguration {
 
             // Padding and EUI48 are DONT-CARE - this is a read-only memory region.
             _padding: [0xFF; 122],
-            eui48: [0xFF; 6],
+            _eui48: [0xFF; 6],
         };
 
         config.update_crc32();

--- a/src/settings/eeprom/sinara.rs
+++ b/src/settings/eeprom/sinara.rs
@@ -5,7 +5,7 @@ use core::convert::TryInto;
 
 /// The sinara configuration board ID.
 pub enum BoardId {
-    Mainboard = 21,
+    _Mainboard = 21,
     RfChannel = 22,
 }
 
@@ -211,7 +211,7 @@ impl SinaraConfiguration {
     /// * `mainboard` - Specified true if the sinara configuration is for the booster mainboard.
     pub fn default(board_id: BoardId) -> SinaraConfiguration {
         let name = match board_id {
-            BoardId::Mainboard => "Booster",
+            BoardId::_Mainboard => "Booster",
             BoardId::RfChannel => "Booster_Ch",
         };
 

--- a/src/settings/flash.rs
+++ b/src/settings/flash.rs
@@ -201,8 +201,6 @@ impl serial_settings::Platform<5> for SerialSettingsPlatform {
                 // the device. This will allow RF channels to re-enable.
                 platform::clear_reset_flags();
             }
-
-            // TODO: Add command to save RF channel transforms to EEPROM.
             other => {
                 writeln!(
                     self.interface_mut(),

--- a/src/settings/flash.rs
+++ b/src/settings/flash.rs
@@ -139,7 +139,7 @@ impl serial_settings::Platform<5> for SerialSettingsPlatform {
         };
 
         if let Some(path) = key {
-            save_setting(path.into()).unwrap()
+            save_setting(path.parse().unwrap()).unwrap()
         } else {
             for path in Self::Settings::iter_paths::<String<64>>("/") {
                 // TODO: Should we reserve the RF transforms to exist in RF channel EEPROM? These are

--- a/src/settings/flash.rs
+++ b/src/settings/flash.rs
@@ -143,7 +143,8 @@ impl serial_settings::Platform<5> for SerialSettingsPlatform {
         } else {
             for path in Self::Settings::iter_paths::<String<64>>("/") {
                 // TODO: Should we reserve the RF transforms to exist in RF channel EEPROM? These are
-                // likely hardware- and channel-specific.
+                // likely hardware- and channel-specific. Tracking issue is
+                // https://github.com/quartiq/booster/issues/404
                 save_setting(path.unwrap()).unwrap();
             }
         }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,7 +1,6 @@
 //! Booster NGFW NVM settings
 
 use core::fmt::Write;
-use core::str::FromStr;
 use heapless::String;
 use miniconf::Tree;
 
@@ -9,9 +8,8 @@ pub mod eeprom;
 pub mod flash;
 pub mod runtime_settings;
 
-use eeprom::main_board::IpAddr;
+use eeprom::main_board::{Cidr, IpAddr};
 use runtime_settings::RuntimeSettings;
-use smoltcp_nal::smoltcp;
 
 #[derive(Clone, Debug, Tree)]
 pub struct Settings {
@@ -21,29 +19,10 @@ pub struct Settings {
     #[tree(skip)]
     pub mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
 
-    #[tree(validate=Self::validate_ip)]
-    pub ip: String<18>,
+    pub ip: Cidr,
     pub broker: String<255>,
     pub gateway: IpAddr,
     pub id: String<23>,
-}
-
-impl Settings {
-    /// Get the IP address of the device.
-    ///
-    /// # Note
-    /// The IP address will be unspecified if DHCP is to be used.
-    pub fn ip_cidr(&self) -> smoltcp::wire::IpCidr {
-        self.ip.parse().unwrap()
-    }
-
-    fn validate_ip(&mut self, new: String<18>) -> Result<String<18>, &'static str> {
-        match smoltcp::wire::IpCidr::from_str(&new) {
-            Ok(smoltcp::wire::IpCidr::Ipv4(_)) => Ok(new),
-            Ok(_) => Err("IPv6 addresses are not supported"),
-            Err(_) => Err("Please provide a valid IPv4 CIDR (i.e. 192.168.1.1/12"),
-        }
-    }
 }
 
 impl serial_settings::Settings<5> for Settings {
@@ -64,6 +43,6 @@ impl serial_settings::Settings<5> for Settings {
         self.booster.reset();
         self.ip = "0.0.0.0/0".parse().unwrap();
         self.broker = "mqtt".parse().unwrap();
-        self.gateway = IpAddr::new(&[0, 0, 0, 0]);
+        self.gateway = "0.0.0.0".parse().unwrap();
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,7 +1,5 @@
 //! Booster NGFW NVM settings
 
-use crate::hardware::chassis_fans::DEFAULT_FAN_SPEED;
-use crate::net::mqtt_control::DEFAULT_TELEMETRY_PERIOD_SECS;
 use core::fmt::Write;
 use core::str::FromStr;
 use heapless::String;
@@ -68,19 +66,11 @@ impl serial_settings::Settings<5> for Settings {
         )
         .unwrap();
 
-        *self = Self {
-            mac: self.mac,
-            ip: IpAddr::new(&[0, 0, 0, 0]),
-            broker: heapless::String::from_str("10.0.0.2").unwrap(),
-            gateway: IpAddr::new(&[0, 0, 0, 0]),
-            netmask: IpAddr::new(&[0, 0, 0, 0]),
-            id: name,
-            booster: RuntimeSettings {
-                fan_speed: DEFAULT_FAN_SPEED,
-                telemetry_period: DEFAULT_TELEMETRY_PERIOD_SECS,
-                channel: self.booster.channel,
-            },
-        };
-        // TODO: Reset each channel config.
+        self.booster.reset();
+        self.ip = IpAddr::new(&[0, 0, 0, 0]);
+        self.broker = heapless::String::from_str("10.0.0.2").unwrap();
+        self.gateway = IpAddr::new(&[0, 0, 0, 0]);
+        self.netmask = IpAddr::new(&[0, 0, 0, 0]);
+        self.id = name;
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -28,17 +28,7 @@ pub struct Settings {
 impl serial_settings::Settings<5> for Settings {
     fn reset(&mut self) {
         self.id.clear();
-        write!(
-            &mut self.id,
-            "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
-            self.mac.0[0],
-            self.mac.0[1],
-            self.mac.0[2],
-            self.mac.0[3],
-            self.mac.0[4],
-            self.mac.0[5]
-        )
-        .unwrap();
+        write!(&mut self.id, "{}", self.mac).unwrap();
 
         self.booster.reset();
         self.ip = "0.0.0.0/0".parse().unwrap();

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,29 +1,86 @@
 //! Booster NGFW NVM settings
 
-pub mod channel_settings;
+use crate::hardware::chassis_fans::DEFAULT_FAN_SPEED;
+use crate::net::mqtt_control::DEFAULT_TELEMETRY_PERIOD_SECS;
+use core::fmt::Write;
+use core::str::FromStr;
+use heapless::String;
+use miniconf::Tree;
+
+pub mod eeprom;
 pub mod flash;
-pub mod global_settings;
 pub mod runtime_settings;
-mod sinara;
-use encdec::{Decode, DecodeOwned, Encode};
-use serde::{Deserialize, Serialize};
 
-use sinara::{BoardId as SinaraBoardId, SinaraConfiguration};
+use eeprom::main_board::IpAddr;
+use runtime_settings::RuntimeSettings;
+use smoltcp_nal::smoltcp;
 
-pub use channel_settings::BoosterChannelSettings;
-pub use global_settings::BoosterSettings;
+#[derive(Clone, Debug, Tree)]
+pub struct Settings {
+    #[tree(depth = 4)]
+    pub booster: RuntimeSettings,
 
-/// A semantic version control for recording software versions.
-#[derive(Encode, DecodeOwned, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
-pub struct SemVersion {
-    major: u8,
-    minor: u8,
-    patch: u8,
+    #[tree(skip)]
+    pub mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
+
+    pub ip: IpAddr,
+    pub broker: heapless::String<255>,
+    pub gateway: IpAddr,
+    pub netmask: IpAddr,
+    pub id: heapless::String<23>,
 }
 
-impl SemVersion {
-    /// Determine if this version is compatible with `rhs`.
-    pub fn is_compatible_with(&self, rhs: &SemVersion) -> bool {
-        (self.major == rhs.major) && (self.minor <= rhs.minor)
+impl Settings {
+    /// Get the IP address of the device.
+    ///
+    /// # Note
+    /// The IP address will be unspecified if DHCP is to be used.
+    pub fn ip_cidr(&self) -> smoltcp::wire::IpCidr {
+        let ip_addr = self.ip.0;
+
+        let prefix = if !ip_addr.is_unspecified() {
+            let netmask = smoltcp::wire::IpAddress::Ipv4(self.netmask.0);
+
+            netmask.prefix_len().unwrap_or_else(|| {
+                log::error!("Invalid netmask found. Assuming no mask.");
+                0
+            })
+        } else {
+            0
+        };
+
+        smoltcp::wire::IpCidr::new(smoltcp::wire::IpAddress::Ipv4(ip_addr), prefix)
+    }
+}
+
+impl serial_settings::Settings<5> for Settings {
+    fn reset(&mut self) {
+        let mut name: String<23> = String::new();
+        write!(
+            &mut name,
+            "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
+            self.mac.0[0],
+            self.mac.0[1],
+            self.mac.0[2],
+            self.mac.0[3],
+            self.mac.0[4],
+            self.mac.0[5]
+        )
+        .unwrap();
+
+        *self = Self {
+            mac: self.mac,
+            ip: IpAddr::new(&[0, 0, 0, 0]),
+            broker: heapless::String::from_str("10.0.0.2").unwrap(),
+            gateway: IpAddr::new(&[0, 0, 0, 0]),
+            netmask: IpAddr::new(&[0, 0, 0, 0]),
+            id: name,
+            booster: RuntimeSettings {
+                fan_speed: DEFAULT_FAN_SPEED,
+                telemetry_period: DEFAULT_TELEMETRY_PERIOD_SECS,
+                channel: self.booster.channel,
+            },
+        };
+        // TODO: Reset each channel config.
     }
 }

--- a/src/settings/runtime_settings.rs
+++ b/src/settings/runtime_settings.rs
@@ -1,10 +1,10 @@
 //! Booster NGFW runtime settings
 
-use super::channel_settings::ChannelSettings;
+use super::eeprom::rf_channel::ChannelSettings;
 use crate::{hardware, net};
 use miniconf::Tree;
 
-#[derive(Clone, Tree)]
+#[derive(Clone, Debug, Tree)]
 pub struct RuntimeSettings {
     #[tree(depth = 3)]
     pub channel: [Option<ChannelSettings>; 8],

--- a/src/settings/runtime_settings.rs
+++ b/src/settings/runtime_settings.rs
@@ -4,6 +4,9 @@ use super::eeprom::rf_channel::ChannelSettings;
 use crate::{hardware, net};
 use miniconf::Tree;
 
+use crate::hardware::chassis_fans::DEFAULT_FAN_SPEED;
+use crate::net::mqtt_control::DEFAULT_TELEMETRY_PERIOD_SECS;
+
 #[derive(Clone, Debug, Tree)]
 pub struct RuntimeSettings {
     #[tree(depth = 3)]
@@ -34,6 +37,18 @@ impl RuntimeSettings {
             Ok(new)
         } else {
             Err("Invalid fan speed. Must be within range [0, 1.0]")
+        }
+    }
+
+    pub fn reset(&mut self) {
+        for channel in self.channel.iter_mut().flatten() {
+            *channel = ChannelSettings::default();
+        }
+
+        *self = Self {
+            fan_speed: DEFAULT_FAN_SPEED,
+            telemetry_period: DEFAULT_TELEMETRY_PERIOD_SECS,
+            channel: self.channel,
         }
     }
 }


### PR DESCRIPTION
This PR fixes #380 by allowing RF channel settings to be configured via the USB port.

TODO:
- [x] Currently, `serial-settings` will always say that you need to reboot to apply settings. This isn't true for runtime settings.
- [ ] ~Save RF channel transforms into the RF channel EEPROM, not device flash~
    * Deferred to https://github.com/quartiq/booster/issues/404
- [x] Make `clear` reset the RF channel configurations