### PR TITLE
Feature/mqtt save fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,8 +937,7 @@ dependencies = [
 [[package]]
 name = "minireq"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64600b540ee248a33ecae6fe10c65b53ae06255c3cb5afc894a608dc8b15749d"
+source = "git+https://github.com/quartiq/minireq?branch=feature/default-handler#7c0bf1a8f999b1b36a57c74f2e4d34bf8534b587"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ dependencies = [
 [[package]]
 name = "minireq"
 version = "0.4.0"
-source = "git+https://github.com/quartiq/minireq?branch=feature/default-handler#7c0bf1a8f999b1b36a57c74f2e4d34bf8534b587"
+source = "git+https://github.com/quartiq/minireq#ab28a95aa40227e1f3cb32772bdf422e221cae6a"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,7 @@ miniconf_mqtt = "0.11"
 minimq = "0.9.0"
 w5500 = "0.4.1"
 smlang= "0.6"
-#minireq = "0.4"
-minireq = {git = "https://github.com/quartiq/minireq", branch = "feature/default-handler" }
+minireq = {git = "https://github.com/quartiq/minireq"}
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,8 @@ miniconf_mqtt = "0.11"
 minimq = "0.9.0"
 w5500 = "0.4.1"
 smlang= "0.6"
-minireq = "0.4"
+#minireq = "0.4"
+minireq = {git = "https://github.com/quartiq/minireq", branch = "feature/default-handler" }
 rtt-target = {version = "0.3", features=["cortex-m"]}
 enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = { version = "0.3", features = ["cortex-m-cpu"] }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -86,8 +86,8 @@ impl NetworkDevices {
 
             let mut control = minireq::Minireq::new(&prefix, mqtt).unwrap();
 
-            control.register("save").unwrap();
-            control.register("read-bias").unwrap();
+            control.subscribe("save").unwrap();
+            control.subscribe("read-bias").unwrap();
 
             control
         };

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,6 +1,6 @@
 //! Booster network management definitions
 
-use crate::hardware::{setup::MainBus, NetworkStack, SystemTimer};
+use crate::hardware::{NetworkStack, SystemTimer};
 
 use core::fmt::Write;
 use heapless::String;
@@ -13,7 +13,6 @@ pub struct MqttStorage {
     telemetry: [u8; 1024],
     settings: [u8; 1024],
     control: [u8; 1024],
-    minireq_handlers: [minireq::HandlerSlot<'static, MainBus, mqtt_control::Error>; 2],
 }
 
 impl Default for MqttStorage {
@@ -22,7 +21,6 @@ impl Default for MqttStorage {
             telemetry: [0u8; 1024],
             settings: [0u8; 1024],
             control: [0u8; 1024],
-            minireq_handlers: [None, None],
         }
     }
 }
@@ -44,11 +42,9 @@ pub struct NetworkDevices {
     >,
     pub control: minireq::Minireq<
         'static,
-        MainBus,
         NetworkStackProxy,
         SystemTimer,
         minireq::minimq::broker::NamedBroker<NetworkStackProxy>,
-        mqtt_control::Error,
     >,
     stack: NetworkStackProxy,
 }
@@ -88,15 +84,10 @@ impl NetworkDevices {
                 .unwrap();
             let mqtt = minireq::minimq::Minimq::new(shared.acquire_stack(), clock, config);
 
-            let mut control =
-                minireq::Minireq::new(&prefix, mqtt, &mut store.minireq_handlers).unwrap();
+            let mut control = minireq::Minireq::new(&prefix, mqtt).unwrap();
 
-            control
-                .register("save", mqtt_control::save_settings)
-                .unwrap();
-            control
-                .register("read-bias", mqtt_control::read_bias)
-                .unwrap();
+            control.register("save").unwrap();
+            control.register("read-bias").unwrap();
 
             control
         };

--- a/src/net/mqtt_control.rs
+++ b/src/net/mqtt_control.rs
@@ -267,7 +267,7 @@ pub fn save_settings_to_flash(
 
     let settings = channel.context().settings();
     let mut root_path: String<64> = "/booster/channel".parse().unwrap();
-    write!(&mut root_path, "/{}", request.channel as usize);
+    write!(&mut root_path, "/{}", request.channel as usize).unwrap();
 
     let mut buf = [0u8; 256];
     for channel_path in ChannelSettings::iter_paths::<String<64>>("/") {
@@ -275,11 +275,11 @@ pub fn save_settings_to_flash(
         let mut path = root_path.clone();
         path.push_str(&channel_path).unwrap();
 
-        let mut data = Vec::new();
-        data.resize(data.len(), 0);
+        let mut data: Vec<u8, 256> = Vec::new();
+        data.resize(data.capacity(), 0).unwrap();
         let flavor = postcard::ser_flavors::Slice::new(&mut data);
         let len = settings
-            .get_postcard_by_key(channel_path.split("/").skip(1), flavor)
+            .get_postcard_by_key(channel_path.split('/').skip(1), flavor)
             .unwrap()
             .len();
         data.truncate(len);

--- a/src/settings/flash.rs
+++ b/src/settings/flash.rs
@@ -75,12 +75,10 @@ pub struct SerialSettingsPlatform {
 
 impl SerialSettingsPlatform {
     pub fn save_item(&mut self, buffer: &mut [u8], key: String<64>, value: Vec<u8, 256>) {
-        let mut item = SettingsItem {
+        let item = SettingsItem {
             path: key,
             data: value,
         };
-
-        item.data.resize(item.data.capacity(), 0).unwrap();
 
         let range = self.storage.range();
 


### PR DESCRIPTION
Fixes #405 by updating the MQTT `save` command to save to internal flash instead of channel EEPROM.

We likely want to merge https://github.com/quartiq/minireq/pull/20 first.