### PR TITLE
Updating smoltcp to prevent DoS during network floods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   firmware variants will still be able to use existing EEPROM settings, but the EEPROM contents
   are no longer modified when settings are changed.
 
+### Fixed
+* Heavy network traffic no longer causes Booster to encounter watchdog resets or other spurious
+resets.
+
 ## [0.5.0] - 03-07-2023
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,6 @@ dependencies = [
  "rtic",
  "rtic-monotonics",
  "rtic-sync",
- "rtt-logger",
  "rtt-target",
  "sequential-storage",
  "serde",
@@ -1245,22 +1244,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtt-logger"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f42c228caf6eab0fe8374ef3988b9db07dbe0b12b65b4a02aaacb48b03354e"
-dependencies = [
- "log",
- "rtt-target",
-]
-
-[[package]]
 name = "rtt-target"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
+checksum = "10b34c9e6832388e45f3c01f1bb60a016384a0a4ad80cdd7d34913bed25037f0"
 dependencies = [
- "cortex-m",
+ "critical-section",
  "ufmt-write",
 ]
 
@@ -1425,8 +1414,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1a996951e50b5971a2c8c0fa05a381480d70a933064245c4a223ddc87ccc97"
+source = "git+https://github.com/quartiq/smoltcp?rev=091fbfb828e2a8f52f9d17d46ce24ba632d9920e#091fbfb828e2a8f52f9d17d46ce24ba632d9920e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ heapless = { version = "0.8", features = ["serde"] }
 bit_field = "0.10.2"
 debounced-pin = {git = "https://github.com/quartiq/rust-debounced-pin"}
 serde = {version = "1.0", features = ["derive"], default-features = false }
-rtt-logger = "0.2"
 bbqueue = "0.5"
 embedded-hal-bus = "0.2"
 usb-device = "0.3.2"
@@ -59,7 +58,7 @@ minimq = "0.9.0"
 w5500 = "0.5"
 smlang= "0.6"
 minireq = {git = "https://github.com/quartiq/minireq"}
-rtt-target = {version = "0.3", features=["cortex-m"]}
+rtt-target = "0.5"
 enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = "0.4"
 embedded-hal = "1"
@@ -76,6 +75,10 @@ built = { version = "0.7", features = ["git2"], default-features = false }
 [dependencies.ad5627]
 path = "ad5627"
 version = "0.2"
+
+[patch.crates-io.smoltcp]
+git = "https://github.com/quartiq/smoltcp"
+rev = "091fbfb828e2a8f52f9d17d46ce24ba632d9920e"
 
 [dependencies.ads7924]
 path = "ads7924"

--- a/src/hardware/rf_channel.rs
+++ b/src/hardware/rf_channel.rs
@@ -155,7 +155,7 @@ impl Devices {
     ) -> Option<(Self, Microchip24AA02E48<I2cProxy>)> {
         // The ADS7924 and DAC7571 are present on the booster mainboard, so instantiation
         // and communication should never fail.
-        let mut dac7571 = Dac7571::default(i2c::AtomicDevice::new(&manager));
+        let mut dac7571 = Dac7571::default(i2c::AtomicDevice::new(manager));
 
         // Ensure the bias DAC is placing the RF amplifier in pinch off (disabled).
         dac7571
@@ -163,7 +163,7 @@ impl Devices {
             .expect("Bias DAC did not respond");
 
         // Verify we can communicate with the power monitor.
-        let mut ads7924 = Ads7924::default(i2c::AtomicDevice::new(&manager), delay)
+        let mut ads7924 = Ads7924::default(i2c::AtomicDevice::new(manager), delay)
             .expect("Power monitor did not enumerate");
         ads7924
             .get_voltage(ads7924::Channel::Three)
@@ -176,11 +176,11 @@ impl Devices {
         assert!(ads7924.clear_alarm().expect("Failed to clear alarm") == 0);
 
         // Query devices on the RF module to verify they are present.
-        let ad5627 = Ad5627::default(i2c::AtomicDevice::new(&manager)).ok()?;
-        let eui48 = Microchip24AA02E48::new(i2c::AtomicDevice::new(&manager)).ok()?;
-        let mut max6642 = Max6642::att94(i2c::AtomicDevice::new(&manager));
+        let ad5627 = Ad5627::default(i2c::AtomicDevice::new(manager)).ok()?;
+        let eui48 = Microchip24AA02E48::new(i2c::AtomicDevice::new(manager)).ok()?;
+        let mut max6642 = Max6642::att94(i2c::AtomicDevice::new(manager));
         max6642.get_remote_temperature().ok()?;
-        let mut mcp3221 = Mcp3221::default(i2c::AtomicDevice::new(&manager));
+        let mut mcp3221 = Mcp3221::default(i2c::AtomicDevice::new(manager));
         mcp3221.get_voltage().ok()?;
 
         Some((

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,8 +3,8 @@ use heapless::String;
 
 use super::SerialTerminal;
 use core::fmt::Write;
-use rtt_target::rprintln;
 use log::LevelFilter;
+use rtt_target::rprintln;
 
 /// A logging buffer for storing serialized logs pending transmission.
 ///

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,6 +3,8 @@ use heapless::String;
 
 use super::SerialTerminal;
 use core::fmt::Write;
+use rtt_target::rprintln;
+use log::LevelFilter;
 
 /// A logging buffer for storing serialized logs pending transmission.
 ///
@@ -12,7 +14,7 @@ use core::fmt::Write;
 /// USB task.
 pub struct BufferedLog {
     logs: heapless::mpmc::Q16<heapless::String<256>>,
-    rtt_logger: rtt_logger::RTTLogger,
+    level_filter: LevelFilter,
 }
 
 impl BufferedLog {
@@ -20,7 +22,7 @@ impl BufferedLog {
     pub const fn new() -> Self {
         Self {
             logs: heapless::mpmc::Q16::new(),
-            rtt_logger: rtt_logger::RTTLogger::new(log::LevelFilter::Info),
+            level_filter: LevelFilter::Info,
         }
     }
 
@@ -40,12 +42,16 @@ impl BufferedLog {
 }
 
 impl log::Log for BufferedLog {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
-        true
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.level_filter.ge(&metadata.level())
     }
 
     fn log(&self, record: &log::Record) {
-        self.rtt_logger.log(record);
+        if self.enabled(record.metadata()) == false {
+            return;
+        }
+
+        rprintln!("{} - {}", record.level(), record.args());
         let source_file = record.file().unwrap_or("Unknown");
         let source_line = record.line().unwrap_or(u32::MAX);
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -47,7 +47,7 @@ impl log::Log for BufferedLog {
     }
 
     fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) == false {
+        if !self.enabled(record.metadata()) {
             return;
         }
 


### PR DESCRIPTION
This PR fixes #337 by updating the `smoltcp` dependency to use a branch where the maximum MAC frame processing loop of `smoltcp` is limited by the sockets in use (in our case, 1 frame per `poll()` call).

It also updates logging to get rid of an extra dependency.

I programmed `stabilizer` to stream to multicast `244.192.168.1:9293` and verified that stream data could be acquired using the `stabilizer-streaming` `pds` binary. I then programmed `booster` with `main` firmware and verified that the device continually reset due to watchdog timeouts. I then tried this new firmware and confirmed that no further watchdogs were encountered.