### PR TITLE
Updating sequential-storage implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,12 +1381,15 @@ dependencies = [
 [[package]]
 name = "serial-settings"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/stabilizer?rev=5452272931e1ad70547b578052ffbb186fb72514#5452272931e1ad70547b578052ffbb186fb72514"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e625da19d0598abfecd5f8ead895ec4542c79a3139234cc7fd9cb3fe3ba0ff"
 dependencies = [
  "embedded-io",
  "heapless 0.8.0",
+ "log",
  "menu",
  "miniconf",
+ "postcard",
  "yafnv",
 ]
 
@@ -1751,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "yafnv"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66aad9090f952997c6570d94039d80b5b5e26d182c5f39ef7b05d64535fb5f88"
+checksum = "a98cd19b5e3fbcda406d58efc9f5cb2d6e82e381708d52f357b3b3cfb19559b1"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ enc424j600 = "0.4"
 embedded-hal = "1"
 smoltcp-nal = { version = "0.5", features=["shared-stack"] }
 
-serial-settings = {git = "https://github.com/quartiq/stabilizer", rev = "5452272931e1ad70547b578052ffbb186fb72514"}
+serial-settings = "0.1"
 stm32f4xx-hal = {version = "0.21.0", features = ["stm32f407", "usb_fs"] }
 
 postcard = "1"

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -45,8 +45,10 @@ pub enum Mac {
     Enc424j600(enc424j600::Enc424j600<SpiDevice>),
 }
 
-pub type SerialTerminal =
-    serial_settings::Runner<'static, crate::settings::flash::SerialSettingsPlatform, 5>;
+pub type SerialSettingsPlatform =
+    crate::settings::flash::SerialSettingsPlatform<crate::settings::Settings, 5>;
+
+pub type SerialTerminal = serial_settings::Runner<'static, SerialSettingsPlatform, 5>;
 
 pub type NetworkStack = smoltcp_nal::NetworkStack<'static, Mac, SystemTimer>;
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -330,7 +330,7 @@ pub fn setup(
     // values stored in flash. This helps preserve backwards compatibility with older Booster
     // firmware versions that didn't store settings in flash. We no longer persist settings to
     // EEPROM, so flash will have the latest and greatest settings data.
-    crate::settings::flash::load_from_flash(&mut settings, &mut flash);
+    crate::settings::flash::SerialSettingsPlatform::load(&mut settings, &mut flash);
 
     let mut mac = {
         let mut spi = {
@@ -548,6 +548,7 @@ pub fn setup(
         serial_settings::Runner::new(
             crate::settings::flash::SerialSettingsPlatform {
                 metadata,
+                _settings_marker: core::marker::PhantomData,
                 interface: serial_settings::BestEffortInterface::new(usb_serial),
                 storage: flash,
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,10 +250,12 @@ mod app {
                 .lock(|watchdog| watchdog.check_in(WatchdogClient::Usb));
 
             (&mut c.shared.usb_terminal, &mut c.shared.settings).lock(|terminal, settings| {
+                // Handle the USB serial terminal.
                 c.local.usb.process(terminal);
-                if terminal.process(settings).unwrap() {
-                    update_settings::spawn().unwrap();
+                if terminal.poll(settings).unwrap() {
+                    update_settings::spawn().unwrap()
                 }
+
                 // Process any log output.
                 LOGGER.process(terminal);
             });

--- a/src/net/mqtt_control.rs
+++ b/src/net/mqtt_control.rs
@@ -13,8 +13,10 @@ use core::fmt::Write;
 use heapless::{String, Vec};
 use serde::Serialize;
 
-use crate::settings::{flash::SerialSettingsPlatform, Settings};
+use crate::hardware::SerialSettingsPlatform;
+use crate::settings::Settings;
 use miniconf::{IntoKeys, Keys, Path, Postcard, TreeKey};
+use serial_settings::Platform;
 
 /// Default metadata message if formatting errors occur.
 const DEFAULT_METADATA: &str = "{\"message\":\"Truncated: See USB terminal\"}";
@@ -266,7 +268,9 @@ pub fn save_settings_to_flash(
             .len();
         data.truncate(len);
 
-        settings_platform.save_item(&mut buf[..], channel_path.0, data);
+        settings_platform
+            .store(&mut buf[..], channel_path.0.as_bytes(), &data)
+            .map_err(|_| "Failed to save to flash")?;
     }
 
     Ok(0)


### PR DESCRIPTION
At this point, nearly the entire `flash.rs` file is a copy-and-paste from Stabilizer, so it would definitely make some sense to abstract this all out. Maybe we could even move a lot of this directly into `serial-settings`? TBD.