### PR TITLE
Replacing pin debounce crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "cortex-m-rt",
  "crc-any",
  "dac7571",
- "debounced-pin",
+ "debouncr",
  "embassy-futures",
  "embedded-hal 1.0.0",
  "embedded-hal-bus 0.2.0",
@@ -325,11 +325,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "debounced-pin"
-version = "0.3.0"
-source = "git+https://github.com/quartiq/rust-debounced-pin#1a48fcd8c2759d12543c57649acdd15431ef2421"
+name = "debouncr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d141ae1bf4aa25e3d1981ef8426c60d0087b4417ad891bbf762e45f173906b"
 dependencies = [
- "embedded-hal 1.0.0",
+ "doc-comment",
 ]
 
 [[package]]
@@ -351,6 +352,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "document-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ cortex-m-log = { version = "0.8.0", features = ["log-integration"] }
 log = "0.4.22"
 heapless = { version = "0.8", features = ["serde"] }
 bit_field = "0.10.2"
-debounced-pin = {git = "https://github.com/quartiq/rust-debounced-pin"}
+debouncr = "0.2"
 serde = {version = "1.0", features = ["derive"], default-features = false }
 bbqueue = "0.5"
 embedded-hal-bus = "0.2"


### PR DESCRIPTION
This replaces a forked debounce crate with a simpler alternative. It's actually less code and still functions the same. I verified that the buttons on the front panel still operate how I'd expect them to.