### PR TITLE
Fixing CI attachment upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
+        if: github.ref == 'refs/heads/main'
         with:
           name: Firmware Images
           path: |


### PR DESCRIPTION
CI needs to build the images so I can attach them to the release (i.e. for DFU support).