### PR TITLE
calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The default output power interlock threshold has been increased from 0 dBm to 20 dBm.
 
+### Added
+
+* Booster CLI tool support for power transform calibrations.
+
 ## [0.6.0] - 2024-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - DATE
+
+### Changed
+
+* The default output power interlock threshold has been increased from 0 dBm to 20 dBm.
+
 ## [0.6.0] - 2024-08-28
 
 ### Changed

--- a/py/booster/__init__.py
+++ b/py/booster/__init__.py
@@ -45,7 +45,6 @@ class Booster:
             client: A connected MQTT5 client.
             prefix: The prefix of the booster to control.
         """
-        self.prefix = prefix
         self.miniconf = miniconf.Miniconf(client, prefix)
 
     async def perform_action(self, action: Action, channel: str):
@@ -61,7 +60,7 @@ class Booster:
         message = json.dumps({"channel": CHANNEL[channel]})
 
         return await self.miniconf._do(
-            f"{self.prefix}/command/{action.value}", payload=message
+            f"{self.miniconf.prefix}/command/{action.value}", payload=message
         )
 
     async def tune_bias(self, channel, current):

--- a/py/booster/__init__.py
+++ b/py/booster/__init__.py
@@ -9,6 +9,7 @@ import time
 import json
 import enum
 import logging
+import sys
 
 import miniconf
 from aiomqtt import MqttError
@@ -123,3 +124,122 @@ class Booster:
                 break
 
         return vgs, ids
+
+    async def calibrate(self, channel, transform):
+        """Calibrate a linear transform.
+
+        Args:
+            channel: The channel to calibrate the transform on.
+            transform: The transform to calibrate (input, output, reflected)
+
+        Returns:
+            The transform
+        """
+        backup = {}
+        for k in f"/channel/{channel}/state /telemetry_period".split():
+            backup[k] = json.loads(await self.miniconf.get(k))
+
+        try:
+            print(
+                f"""Calibrating the `{transform}` power detector linear transform on channel {channel}.
+
+The transform calibration routine requires two different operating powers.
+For optimal accuracy, they should support the desired operating power range
+and both be at the same input signal carrier frequency representative of the
+desired operating frequency range.
+
+For each power condition, establish it, determine the true power by measuring it and
+input it at the prompt. The routine determines the apparent power and computes a new
+corrected transform."""
+            )
+            await self.miniconf.set(f"/channel/{channel}/state", "Enabled")
+            await asyncio.sleep(0.4)
+            await self.miniconf.set(f"/telemetry_period", 1)
+
+            # This is merely to avoid the queue full warnings
+            # and the inconvenient async-iterator-only interface of aiomqtt
+            queue = asyncio.Queue(1)
+
+            async def tele():
+                async with miniconf.Client(
+                    self.miniconf.client._hostname,
+                    protocol=miniconf.MQTTv5,
+                ) as tele:
+                    topic = f"{self.miniconf.prefix}/telemetry/ch{channel}"
+                    await tele.subscribe(topic)
+                    try:
+                        async for msg in tele.messages:
+                            try:
+                                queue.put_nowait(msg)
+                            except asyncio.QueueFull:
+                                continue
+                    except asyncio.CancelledError:
+                        pass
+                    finally:
+                        await tele.unsubscribe(topic)
+
+            cal = []
+            async with asyncio.TaskGroup() as tg:
+                tele = tg.create_task(tele())
+                for i in range(2):
+                    while True:
+                        try:
+                            true = float(
+                                await ainput(
+                                    f"Enter current true `{transform}` power in dBm:"
+                                )
+                            )
+                            break
+                        except ValueError as e:
+                            print(f"Error: {e}, try again")
+                    while True:
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                    msg = json.loads((await queue.get()).payload)
+                    if (
+                        msg["reflected_overdrive"]
+                        or msg["output_overdrive"]
+                        or msg["alert"]
+                        or msg["state"] != "Enabled"
+                    ):
+                        raise ValueError(
+                            "Channel tripped, overdriven, or in alert condition: ", msg
+                        )
+                    apparent = msg[f"{transform}_power"]
+                    print(f"Current apparent `{transform}` power: {apparent} dBm")
+                    cal.append((apparent, true))
+                tele.cancel()
+
+            current = json.loads(
+                await self.miniconf.get(
+                    f"/channel/{channel}/{transform}_power_transform"
+                )
+            )
+            print(f"Current `{transform}` transform: {current}")
+            (qa, pa), (qb, pb) = cal
+            pm = (pa + pb) / 2
+            qm = (qa + qb) / 2
+            dpdq = (pa - pb) / (qa - qb)
+            new = dict(
+                slope=dpdq * current["slope"],
+                offset=pm + dpdq * (current["offset"] - qm),
+            )
+            print(f"Proposed new `{transform}` transform: {new}")
+            if await ainput("Enter `y` to set new transform:") == "y":
+                await self.miniconf.set(
+                    f"/channel/{channel}/{transform}_power_transform", new
+                )
+                print("Set (use `save` to write to flash memory)")
+            else:
+                print("Not set")
+
+        finally:
+            for k, v in backup.items():
+                await self.miniconf.set(k, v)
+
+
+async def ainput(string: str) -> str:
+    print(string, end=" ", flush=True)
+    return (await asyncio.to_thread(sys.stdin.readline)).rstrip("\n")

--- a/py/booster/__init__.py
+++ b/py/booster/__init__.py
@@ -60,7 +60,7 @@ class Booster:
         """
         message = json.dumps({"channel": CHANNEL[channel]})
 
-        await self.miniconf._do(
+        return await self.miniconf._do(
             f"{self.prefix}/command/{action.value}", payload=message
         )
 
@@ -81,9 +81,10 @@ class Booster:
 
         async def set_bias(voltage):
             await self.miniconf.set(f"/channel/{channel}/bias_voltage", voltage)
-            # Sleep 100 ms for bias current to settle and for ADC to take current measurement.
+            # Sleep 200 ms for bias current to settle and for ADC to take current measurement.
             await asyncio.sleep(0.2)
             response = await self.perform_action(Action.ReadBiasCurrent, channel)
+            response = json.loads(response[0])
             vgs, ids = response["vgs"], response["ids"]
             print(f"Vgs = {vgs:.3f} V, Ids = {ids * 1000:.2f} mA")
             return vgs, ids

--- a/py/booster/__init__.py
+++ b/py/booster/__init__.py
@@ -58,16 +58,11 @@ class Booster:
         Returns:
             The received response to the action.
         """
-        message = json.dumps(
-            {
-                "channel": CHANNEL[channel],
-            }
-        )
+        message = json.dumps({"channel": CHANNEL[channel]})
 
-        response = await self.miniconf._do(
+        await self.miniconf._do(
             f"{self.prefix}/command/{action.value}", payload=message
         )
-        return json.loads(response[0])
 
     async def tune_bias(self, channel, current):
         """Set a booster RF bias current.

--- a/py/booster/__main__.py
+++ b/py/booster/__main__.py
@@ -6,18 +6,10 @@ Description: Provides an API for controlling Booster NGFW over MQTT.
 """
 import argparse
 import asyncio
-import os
-import sys
 import logging
 
 from . import Booster, Action
 import miniconf
-
-if sys.platform.lower() == "win32" or os.name.lower() == "nt":
-    from asyncio import set_event_loop_policy, WindowsSelectorEventLoopPolicy
-
-    set_event_loop_policy(WindowsSelectorEventLoopPolicy())
-
 
 # A dictionary of all the available commands, their number of arguments, argument type, and help
 # information about the command.

--- a/py/booster/__main__.py
+++ b/py/booster/__main__.py
@@ -23,6 +23,11 @@ CMDS = {
         "type": float,
         "help": "Tune the channel RF drain current to the specified amps",
     },
+    "calibrate": {
+        "nargs": 1,
+        "type": str,
+        "help": "Calibrate a transform (input, output, or reflected)",
+    }
 }
 
 
@@ -112,9 +117,10 @@ def main():
                     print(
                         f"Channel {args.channel}: Vgs = {vgs:.3f} V, Ids = {ids * 1000:.2f} mA"
                     )
+                elif command == "calibrate":
+                    await booster.calibrate(args.channel, cmd_args[0])
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(channel_configuration(parser.parse_args()))
+    asyncio.run(channel_configuration(parser.parse_args()))
 
 
 if __name__ == "__main__":

--- a/py/booster/__main__.py
+++ b/py/booster/__main__.py
@@ -6,10 +6,17 @@ Description: Provides an API for controlling Booster NGFW over MQTT.
 """
 import argparse
 import asyncio
+import os
+import sys
+import logging
 
 from . import Booster, Action
 import miniconf
-import logging
+
+if sys.platform.lower() == "win32" or os.name.lower() == "nt":
+    from asyncio import set_event_loop_policy, WindowsSelectorEventLoopPolicy
+
+    set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 
 # A dictionary of all the available commands, their number of arguments, argument type, and help


### PR DESCRIPTION
- **channel defaults: 20 dBm output interlock**
- **py: fix save**
- **py: add windows loop patch**
- **py: fix action response**
- **remove prefix field from booster**
- **remove duplicate windows loop patch**
- **add changelog entry on interlock threshold change**
- **py: add transform calibration support**
