### PR TITLE
Fix installation instructions for python package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .gdb_history
 target/
 */Cargo.lock
+py/booster.egg-info
+py/build

--- a/book/src/network-interface.md
+++ b/book/src/network-interface.md
@@ -51,6 +51,6 @@ Booster supports channel bias tuning and saving active channel settings configur
 via the Booster python package located in the `py` folder of the repository. Execute the
 following to install the package and see how to use it:
 ```sh
-pip install py
+pip install ./py
 python -m booster --help
 ```


### PR DESCRIPTION
`pip install py` installs https://pypi.org/project/py/, regardless of whether a `py` directory exists in the current directory.