### PR TITLE
Add set_str and set_float commands to python lib

### DIFF
--- a/py/booster/__main__.py
+++ b/py/booster/__main__.py
@@ -21,17 +21,22 @@ CMDS = {
     },
     "tune": {
         "nargs": 1,
-        "type": float,
+        "type": [float],
         "help": "Tune the channel RF drain current to the specified amps",
     },
-    "set": {
+    "set_str": {
         "nargs": 2,
-        "type": str,
-        "help": "Set the given property for the channel to the specified value",
+        "type": [str, str],
+        "help": "Set the given property for the channel to the specified string value (e.g. ip)",
+    },
+    "set_float": {
+        "nargs": 2,
+        "type": [str, float],
+        "help": "Set the given property for the channel to the specified float value (e.g. output_interlock_threshold)",
     },
     "calibrate": {
         "nargs": 1,
-        "type": str,
+        "type": [str],
         "help": "Calibrate a transform (input, output, or reflected)",
     }
 }
@@ -51,7 +56,7 @@ def parse_command(entry):
         assert CMDS[cmd]["nargs"] == len(
             args
         ), f'Invalid args specified. Expected {CMDS[cmd]["nargs"]}, but found {len(args)}'
-        return (cmd, [CMDS[cmd]["type"](x) for x in args])
+        return (cmd, [CMDS[cmd]["type"][i](x) for i, x in enumerate(args)])
 
     except Exception as exception:
         raise Exception(f'Failed to parse command "{entry}": {exception}')
@@ -126,9 +131,9 @@ def main():
                         print(
                             f"Channel {channel}: Vgs = {vgs:.3f} V, Ids = {ids * 1000:.2f} mA"
                         )
-                    elif command == "set":
+                    elif command.startswith("set"):
                         prop = cmd_args[0]
-                        value = json.loads(cmd_args[1])
+                        value = cmd_args[1]
                         await booster.miniconf.set(f"/channel/{channel}/{prop}", value)
                         print(f"Channel {channel} property '{prop}' set to {value}.")
                     elif command == "calibrate":


### PR DESCRIPTION
In the the Python interfacing package `booster`, the set command fails with a `JSONDecodeError`.
This can be tracked down to `json.loads(cmd[1])` which receives a plain string instead of a json-like input structure.
https://github.com/quartiq/booster/blob/667923e309a3fe4dcb19d0f9431940ec7fa8ac49/py/booster/__main__.py#L131

In addition, float values cannot be used at all (e.g. output_interlock_threshold).

This PR splits the set command into set_str and set_float with the necessary type conversions and hints.

Using:

```bash
python -m booster -b IP.OF.MQTT.BROKER -d --prefix "dt/sinara/booster/XX" -c 0 set_float=output_interlock_threshold,33.0

python -m booster -b IP.OF.MQTT.BROKER -d --prefix "dt/sinara/booster/XX" -c 0 set_str=state,Enabled
```