### PR TITLE
Update `smoltcp` to 0.13.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
  "encdec",
  "enum-iterator",
  "fugit",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "max6639",
  "max6642",
@@ -147,6 +147,7 @@ dependencies = [
  "serde_with",
  "serial_settings",
  "smlang 0.8.0",
+ "smoltcp",
  "smoltcp-nal",
  "stm32f4xx-hal",
  "tca9548",
@@ -189,9 +190,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "cortex-m"
@@ -770,6 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32 0.3.1",
+ "serde_core",
  "stable_deref_trait",
 ]
 
@@ -1145,9 +1150,9 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
  "heapless 0.7.17",
@@ -1369,10 +1374,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1388,10 +1394,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1496,25 +1511,25 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "ac729b0a77bd092a3f06ddaddc59fe0d67f48ba0de45a9abe707c2842c7f8767"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "managed",
 ]
 
 [[package]]
 name = "smoltcp-nal"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/smoltcp-nal#0c683a0bf75e8ca2e74c57914da03873897aaa39"
+source = "git+https://github.com/quartiq/smoltcp-nal#01e628c6d13e4272bf5d22365e1ade8f4c8243c1"
 dependencies = [
  "embedded-nal",
  "embedded-time",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "nanorand",
  "shared-bus",
  "smoltcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rand_core = "0.6"
 mono-clock = "0.1"
 cortex-m-log = { version = "0.8.0", features = ["log-integration"] }
 log = "0.4.25"
-heapless = { version = "0.8", features = ["serde"] }
+heapless = { version = "0.9", features = ["serde"] }
 bit_field = "0.10.2"
 debouncr = "0.2"
 serde = {version = "1.0", features = ["derive"], default-features = false }
@@ -63,6 +63,7 @@ rtt-target = { version = "0.6", optional = true }
 enum-iterator = { version = "2.1", default-features = false }
 enc424j600 = "0.4"
 embedded-hal = "1"
+smoltcp = { version = "0.13", default-features = false, features = ["auto-icmp-echo-reply"] }
 smoltcp-nal = { version = "0.7", features=["shared-stack"] }
 serial_settings = "0.2"
 stm32f4xx-hal = {version = "0.22.1", features = ["stm32f407", "usb_fs"] }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,18 +1,20 @@
 //! Booster NGFW logging utilities
-use heapless::String;
+use core::fmt::Write;
+
+use heapless::{mpmc::Queue, String};
+use log::LevelFilter;
 
 use super::SerialTerminal;
-use core::fmt::Write;
-use log::LevelFilter;
 
 /// A logging buffer for storing serialized logs pending transmission.
 ///
 /// # Notes
+///
 /// The BufferedLog contains a character buffer of the log data waiting to be written. It is
 /// intended to be consumed asynchronously. In the case of booster, this log data is consumed in the
 /// USB task.
 pub struct BufferedLog {
-    logs: heapless::mpmc::Q16<heapless::String<256>>,
+    logs: Queue<heapless::String<256>, 16>,
     level_filter: LevelFilter,
 }
 
@@ -20,7 +22,8 @@ impl BufferedLog {
     /// Construct a new buffered log object.
     pub const fn new() -> Self {
         Self {
-            logs: heapless::mpmc::Q16::new(),
+            #[expect(deprecated)]
+            logs: Queue::new(),
             level_filter: LevelFilter::Info,
         }
     }


### PR DESCRIPTION
Also update to `heapless` 0.9, which deprecates `Queue` for not being truly lock-free, which I don't think is a problem for how it is used here.